### PR TITLE
Improve XandraTest.IntegrationCase

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,8 +6,12 @@ defmodule XandraTest.IntegrationCase do
   using do
     quote do
       setup_all do
-        keyspace = "xandra_test_" <> Base.encode16(:crypto.strong_rand_bytes(16))
+        keyspace = "xandra_test_" <> String.replace(inspect(__MODULE__), ".", "")
         unquote(__MODULE__).setup_keyspace(keyspace)
+
+        on_exit(fn ->
+          unquote(__MODULE__).drop_keyspace(keyspace)
+        end)
 
         %{keyspace: keyspace}
       end
@@ -28,5 +32,10 @@ defmodule XandraTest.IntegrationCase do
     WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 1}
     """
     {:ok, _void} = Xandra.execute(conn, statement, [])
+  end
+
+  def drop_keyspace(keyspace) do
+    {:ok, conn} = Xandra.start_link()
+    {:ok, _void} = Xandra.execute(conn, "DROP KEYSPACE IF EXISTS #{keyspace}", [])
   end
 end


### PR DESCRIPTION
We:

* use the module name of the current test case to generate deterministic keyspaces
* drop the keyspace after the test so that most often we leave the database in a clean state after running tests