### PR TITLE
Refactor functions around sending startup options

### DIFF
--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -17,8 +17,8 @@ defmodule Xandra.Connection do
     prepared_cache = Keyword.fetch!(options, :prepared_cache)
 
     with {:ok, socket} <- connect(host, port),
-         {:ok, requested_options} <- Utils.request_options(socket),
-         :ok <- startup_connection(socket, requested_options),
+         {:ok, supported_options} <- Utils.request_options(socket),
+         :ok <- startup_connection(socket, supported_options),
          do: {:ok, %__MODULE__{socket: socket, prepared_cache: prepared_cache}}
   end
 
@@ -96,8 +96,8 @@ defmodule Xandra.Connection do
          do: {:error, Error.new("TCP connect", reason)}
   end
 
-  defp startup_connection(socket, requested_options) do
-    %{"CQL_VERSION" => [cql_version | _]} = requested_options
+  defp startup_connection(socket, supported_options) do
+    %{"CQL_VERSION" => [cql_version | _]} = supported_options
     Utils.startup_connection(socket, %{"CQL_VERSION" => cql_version})
   end
 end

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -17,8 +17,8 @@ defmodule Xandra.Connection do
     prepared_cache = Keyword.fetch!(options, :prepared_cache)
 
     with {:ok, socket} <- connect(host, port),
-         {:ok, options} <- Utils.request_options(socket),
-         :ok <- Utils.startup_connection(socket, options),
+         {:ok, requested_options} <- Utils.request_options(socket),
+         :ok <- startup_connection(socket, requested_options),
          do: {:ok, %__MODULE__{socket: socket, prepared_cache: prepared_cache}}
   end
 
@@ -94,5 +94,10 @@ defmodule Xandra.Connection do
   defp connect(host, port) do
     with {:error, reason} <- :gen_tcp.connect(host, port, @default_socket_options, @default_timeout),
          do: {:error, Error.new("TCP connect", reason)}
+  end
+
+  defp startup_connection(socket, requested_options) do
+    %{"CQL_VERSION" => [cql_version | _]} = requested_options
+    Utils.startup_connection(socket, %{"CQL_VERSION" => cql_version})
   end
 end

--- a/lib/xandra/connection/utils.ex
+++ b/lib/xandra/connection/utils.ex
@@ -36,10 +36,10 @@ defmodule Xandra.Connection.Utils do
   end
 
   @spec startup_connection(:gen_tcp.socket, map) :: :ok | {:error, Error.t}
-  def startup_connection(socket, startup_options) when is_map(startup_options) do
+  def startup_connection(socket, requested_options) when is_map(requested_options) do
     payload =
       Frame.new(:startup)
-      |> Protocol.encode_request(startup_options)
+      |> Protocol.encode_request(requested_options)
       |> Frame.encode()
 
     with :ok <- :gen_tcp.send(socket, payload),

--- a/lib/xandra/connection/utils.ex
+++ b/lib/xandra/connection/utils.ex
@@ -36,10 +36,10 @@ defmodule Xandra.Connection.Utils do
   end
 
   @spec startup_connection(:gen_tcp.socket, map) :: :ok | {:error, Error.t}
-  def startup_connection(socket, options) do
+  def startup_connection(socket, startup_options) when is_map(startup_options) do
     payload =
       Frame.new(:startup)
-      |> Protocol.encode_request(options)
+      |> Protocol.encode_request(startup_options)
       |> Frame.encode()
 
     with :ok <- :gen_tcp.send(socket, payload),

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -12,9 +12,9 @@ defmodule Xandra.Protocol do
     %{frame | body: <<>>}
   end
 
-  def encode_request(%Frame{kind: :startup} = frame, startup_options, _options)
-      when is_map(startup_options) do
-    %{frame | body: encode_string_map(startup_options)}
+  def encode_request(%Frame{kind: :startup} = frame, requested_options, _options)
+      when is_map(requested_options) do
+    %{frame | body: encode_string_map(requested_options)}
   end
 
   def encode_request(%Frame{kind: :query} = frame, %Simple{} = query, options) do

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -12,9 +12,9 @@ defmodule Xandra.Protocol do
     %{frame | body: <<>>}
   end
 
-  def encode_request(%Frame{kind: :startup} = frame, params, _options) when is_map(params) do
-    %{"CQL_VERSION" => [cql_version | _]} = params
-    %{frame | body: encode_string_map(%{"CQL_VERSION" => cql_version})}
+  def encode_request(%Frame{kind: :startup} = frame, startup_options, _options)
+      when is_map(startup_options) do
+    %{frame | body: encode_string_map(startup_options)}
   end
 
   def encode_request(%Frame{kind: :query} = frame, %Simple{} = query, options) do


### PR DESCRIPTION
This change allows us to "negotiate" options in the connection process instead of hardcoding the negotiation logic in the `Xandra.Protocol` module. This will be useful when we have to negotiate compression options at startup.