### PR TITLE
Handle named params for prepared queries by rewriting to positional params

### DIFF
--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -43,8 +43,9 @@ defmodule Xandra.Batch do
   `query` has to be either a simple query (statement) or a prepared query. Note
   that parameters have to be added alongside their corresponding query when
   adding a query to a batch. In contrast with functions like `Xandra.execute/4`,
-  queries in batch queries only support positional paramters and **do not**
-  support named parameters; this is a current Cassandra limitation.
+  queries in batch queries only support positional parameters and **do not**
+  support named parameters; this is a current Cassandra limitation. If a map of
+  named parameters is passed, an `ArgumentError` exception is raised.
 
   ## Examples
 
@@ -71,6 +72,13 @@ defmodule Xandra.Batch do
   def add(%__MODULE__{} = batch, %Prepared{} = prepared, values)
       when is_list(values) do
     add_query(batch, prepared, values)
+  end
+
+  def add(%__MODULE__{}, _query, values) when is_map(values) do
+    raise ArgumentError,
+      "queries inside batch queries only support positional parameters and " <>
+      "not named parameters (because of a Cassandra limitation), got: " <>
+      inspect(values)
   end
 
   defp add_query(batch, query, values) do

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -43,9 +43,10 @@ defmodule Xandra.Batch do
   `query` has to be either a simple query (statement) or a prepared query. Note
   that parameters have to be added alongside their corresponding query when
   adding a query to a batch. In contrast with functions like `Xandra.execute/4`,
-  queries in batch queries only support positional parameters and **do not**
-  support named parameters; this is a current Cassandra limitation. If a map of
-  named parameters is passed, an `ArgumentError` exception is raised.
+  simple queries in batch queries only support positional parameters and **do
+  not** support named parameters; this is a current Cassandra limitation. If a
+  map of named parameters is passed alongside a simple query, an `ArgumentError`
+  exception is raised. Named parameters are supported with prepared queries.
 
   ## Examples
 

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -71,19 +71,8 @@ defmodule Xandra.Batch do
   end
 
   def add(%__MODULE__{} = batch, %Prepared{} = prepared, values)
-      when is_list(values) do
-    add_query(batch, prepared, values)
-  end
-
-  def add(%__MODULE__{} = batch, %Prepared{} = prepared, values) when is_map(values) do
-    positional_values = Enum.map(prepared.bound_columns, fn {_keyspace, _table, name, _type} ->
-      case Map.fetch(values, name) do
-        {:ok, value} -> value
-        :error -> raise "missing named parameter #{inspect(name)} for prepared query in batch"
-      end
-    end)
-
-    add(batch, prepared, positional_values)
+      when is_list(values) or is_map(values) do
+    add_query(batch, prepared, Prepared.normalize_params_to_positional(prepared, values))
   end
 
   def add(%__MODULE__{}, _query, values) when is_map(values) do

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -81,7 +81,7 @@ defmodule Xandra.Batch do
   def add(%__MODULE__{}, _query, values) when is_map(values) do
     raise ArgumentError,
       "non-prepared statements inside batch queries only support positional " <>
-      "parameters (it's a Cassandra limitation), got: #{inspect(values)}"
+      "parameters (this is a current Cassandra limitation), got: #{inspect(values)}"
   end
 
   defp add_query(batch, query, values) do

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -70,16 +70,18 @@ defmodule Xandra.Batch do
     add_query(batch, %Simple{statement: statement}, values)
   end
 
-  def add(%__MODULE__{} = batch, %Prepared{} = prepared, values)
-      when is_list(values) or is_map(values) do
-    add_query(batch, prepared, Prepared.normalize_params_to_positional(prepared, values))
+  def add(%__MODULE__{} = batch, %Prepared{} = prepared, values) when is_map(values) do
+    add_query(batch, prepared, Prepared.rewrite_named_params_to_positional(prepared, values))
+  end
+
+  def add(%__MODULE__{} = batch, %Prepared{} = prepared, values) when is_list(values) do
+    add_query(batch, prepared, values)
   end
 
   def add(%__MODULE__{}, _query, values) when is_map(values) do
     raise ArgumentError,
-      "simple queries (not prepared) inside batch queries only support positional " <>
-      "parameters and not named parameters (because of a Cassandra limitation), got: " <>
-      inspect(values)
+      "non-prepared statements inside batch queries only support positional " <>
+      "parameters (it's a Cassandra limitation), got: #{inspect(values)}"
   end
 
   defp add_query(batch, query, values) do

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -14,16 +14,16 @@ defmodule Xandra.Prepared do
   }
 
   @doc false
-  def rewrite_named_params_to_positional(%__MODULE__{} = prepared, named_params)
-      when is_map(named_params) do
+  def rewrite_named_params_to_positional(%__MODULE__{} = prepared, params)
+      when is_map(params) do
     Enum.map(prepared.bound_columns, fn {_keyspace, _table, name, _type} ->
-      case Map.fetch(named_params, name) do
+      case Map.fetch(params, name) do
         {:ok, value} ->
           value
         :error ->
           raise ArgumentError,
             "missing named parameter #{inspect(name)} for prepared query, " <>
-            "got: #{inspect(named_params)}"
+            "got: #{inspect(params)}"
       end
     end)
   end

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -13,6 +13,27 @@ defmodule Xandra.Prepared do
     result_columns: list | nil,
   }
 
+  @doc false
+  def normalize_params_to_positional(prepared, params)
+
+  def normalize_params_to_positional(%__MODULE__{} = prepared, named_params)
+      when is_map(named_params) do
+    Enum.map(prepared.bound_columns, fn {_keyspace, _table, name, _type} ->
+      case Map.fetch(named_params, name) do
+        {:ok, value} ->
+          value
+        :error ->
+          raise ArgumentError,
+            "missing named parameter #{inspect(name)} for prepared query #{inspect(prepared)}, " <>
+            "got parameters: #{inspect(named_params)}"
+      end
+    end)
+  end
+
+  def normalize_params_to_positional(%__MODULE__{}, positional_params) do
+    positional_params
+  end
+
   defimpl DBConnection.Query do
     alias Xandra.{Frame, Protocol}
 
@@ -21,6 +42,8 @@ defmodule Xandra.Prepared do
     end
 
     def encode(prepared, values, options) do
+      values = @for.normalize_params_to_positional(prepared, values)
+
       Frame.new(:execute)
       |> Protocol.encode_request(%{prepared | values: values}, options)
       |> Frame.encode(options[:compressor])

--- a/test/integration/batch_test.exs
+++ b/test/integration/batch_test.exs
@@ -88,8 +88,8 @@ defmodule BatchTest do
     ]
   end
 
-  test "a friendly error is raised if named parameters are used with simple queries" do
-    message = ~r/simple queries \(not prepared\) inside batch queries only support positional/
+  test "an error is raised if named parameters are used with simple queries" do
+    message = ~r/non-prepared statements inside batch queries only support positional/
     assert_raise ArgumentError, message, fn ->
       statement = "INSERT INTO users (id, name) VALUES (:id, :name)"
       Batch.add(Batch.new(), statement, %{"id" => 1, "name" => "Summer"})
@@ -97,7 +97,7 @@ defmodule BatchTest do
   end
 
   test "an error is raised if a named parameter is missing for prepared queries", %{conn: conn} do
-    message = ~r/missing named parameter "name" for prepared query #Xandra\.Prepared<.*>/
+    message = "missing named parameter \"name\" for prepared query, got: %{\"id\" => 1}"
     assert_raise ArgumentError, message, fn ->
       statement = "INSERT INTO users (id, name) VALUES (:id, :name)"
       prepared_insert = Xandra.prepare!(conn, statement)

--- a/test/integration/batch_test.exs
+++ b/test/integration/batch_test.exs
@@ -74,6 +74,13 @@ defmodule BatchTest do
     assert {:error, %Error{reason: :invalid}} = Xandra.execute(conn, invalid_batch)
   end
 
+  test "a friendly error is raised if a query uses named parameters in a batch" do
+    assert_raise ArgumentError, ~r/queries inside batch queries only support/, fn ->
+      batch = Batch.new
+      Batch.add(batch, "SELECT * FROM users WHERE name = :name", %{"name" => "Meg"})
+    end
+  end
+
   test "empty batch", %{conn: conn} do
     assert {:ok, %Void{}} = Xandra.execute(conn, Batch.new())
   end

--- a/test/integration/batch_test.exs
+++ b/test/integration/batch_test.exs
@@ -96,6 +96,16 @@ defmodule BatchTest do
     end
   end
 
+  test "an error is raised if a named parameter is missing for prepared queries", %{conn: conn} do
+    message = ~r/missing named parameter "name" for prepared query #Xandra\.Prepared<.*>/
+    assert_raise ArgumentError, message, fn ->
+      statement = "INSERT INTO users (id, name) VALUES (:id, :name)"
+      prepared_insert = Xandra.prepare!(conn, statement)
+      batch = Batch.add(Batch.new(), prepared_insert, %{"id" => 1})
+      Xandra.execute(conn, batch)
+    end
+  end
+
   test "empty batch", %{conn: conn} do
     assert {:ok, %Void{}} = Xandra.execute(conn, Batch.new())
   end

--- a/test/integration/prepared_test.exs
+++ b/test/integration/prepared_test.exs
@@ -48,4 +48,13 @@ defmodule PreparedTest do
     prepared = Xandra.prepare!(conn, "SELECT * FROM users")
     assert inspect(prepared) == ~s(#Xandra.Prepared<"SELECT * FROM users">)
   end
+
+  test "missing named params raise an error", %{conn: conn} do
+    message = "missing named parameter \"name\" for prepared query, got: %{\"code\" => 1}"
+    assert_raise ArgumentError, message, fn ->
+      statement = "INSERT INTO users (code, name) VALUES (:code, :name)"
+      prepared_insert = Xandra.prepare!(conn, statement)
+      Xandra.execute(conn, prepared_insert, %{"code" => 1})
+    end
+  end
 end


### PR DESCRIPTION
* Named params for simple queries now raise a friendly error message
* Named params for prepared queries now work by being rewritten to positional params behind the scenes