### PR TITLE
Support Cassandra authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This library is in its early stages when it comes to features, but we're already
   * clustering (only random load balancing for now)
   * customizable retry strategies for failed queries
   * user-defined types
+  * authentication
 
-In the future, we plan to add more features, like more strategies for clustering and authentication support. See [the documentation][documentation] for detailed explanation of how the supported features work.
+In the future, we plan to add more features, like more strategies for clustering. See [the documentation][documentation] for detailed explanation of how the supported features work.
 
 ## Installation
 

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -130,7 +130,7 @@ defmodule Xandra do
 
   ## Authentication
 
-  Xandra supports authentication to Cassandra driver. See the documentation for
+  Xandra supports Cassandra authentication. See the documentation for
   `Xandra.Authenticator` for more information.
 
   ## Retrying failed queries
@@ -191,7 +191,7 @@ defmodule Xandra do
       decompressing data. See the "Compression" section in the module
       documentation. By default this option is not present.
 
-    * `:authentication` - (tuple) a tuple of two elements: the authenticator
+    * `:authentication` - (tuple) a two-element tuple: the authenticator
       module to use for authentication and its supported options. See the
       "Authentication" section in the module documentation.
 
@@ -214,9 +214,6 @@ defmodule Xandra do
 
       # Start a connection and register it under a name:
       {:ok, _conn} = Xandra.start_link(name: :xandra)
-
-      # Start a connection that requires authentication:
-      {:ok, conn} = Xandra.start_link(authentication: {MyAuthenticator, foo: "foo", bar: "bar"})
 
       # Start a named pool of connections:
       {:ok, _pool} = Xandra.start_link(name: :xandra_pool, pool: DBConnection.Poolboy)

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -128,6 +128,11 @@ defmodule Xandra do
   executing queries on different nodes based on load balancing strategies. See
   the documentation for `Xandra.Cluster` for more information.
 
+  ## Authentication
+
+  Xandra supports authentication to Cassandra driver. See the documentation for
+  `Xandra.Authenticator` for more information.
+
   ## Retrying failed queries
 
   Xandra takes a customizable and extensible approach to retrying failed queries
@@ -186,6 +191,10 @@ defmodule Xandra do
       decompressing data. See the "Compression" section in the module
       documentation. By default this option is not present.
 
+    * `:authentication` - (tuple) a tuple of two elements: the authenticator
+      module to use for authentication and its supported options. See the
+      "Authentication" section in the module documentation.
+
   The rest of the options are forwarded to `DBConnection.start_link/2`. For
   example, to start a pool of connections to Cassandra, the `:pool` option can
   be used:
@@ -205,6 +214,9 @@ defmodule Xandra do
 
       # Start a connection and register it under a name:
       {:ok, _conn} = Xandra.start_link(name: :xandra)
+
+      # Start a connection that requires authentication:
+      {:ok, conn} = Xandra.start_link(authentication: {MyAuthenticator, foo: "foo", bar: "bar"})
 
       # Start a named pool of connections:
       {:ok, _pool} = Xandra.start_link(name: :xandra_pool, pool: DBConnection.Poolboy)

--- a/lib/xandra/authenticator.ex
+++ b/lib/xandra/authenticator.ex
@@ -1,27 +1,27 @@
 defmodule Xandra.Authenticator do
   @moduledoc """
-  A behaviour module for implementing a Cassandra authenticator
+  A behaviour module for implementing a Cassandra authenticator.
 
-  ## Example
+  ## Examples
 
     defmodule MyAuthenticator do
       @behaviour Xandra.Authenticator
 
       def response_body(options) do
-        [Keyword.fetch(options, :foo), Keyword.fetch(options, :bar)]
+        ["user:", Keyword.fetch!(options, :user), "_password:", Keyword.fetch!(options, :password)]
       end
     end
 
-    # To use your authenticator
+  To use the authenticator defined above:
 
-    Xandra.start_link(authentication: {MyAuthenticator, foo: "foo", bar: "bar"}
+    Xandra.start_link(authentication: {MyAuthenticator, user: "my_user", password: "my_password"}
 
   Xandra supports Cassandra's PasswordAuthenticator by default, see
   `Xandra.Authenticator.Password` for more information.
   """
 
   @doc """
-  Returns an IOdata that's used as the response body to Cassandra server's auth challenge
+  Returns an iodata that's used as the response body to Cassandra's auth challenge.
   """
   @callback response_body(Keyword.t) :: iodata
 end

--- a/lib/xandra/authenticator.ex
+++ b/lib/xandra/authenticator.ex
@@ -14,7 +14,7 @@ defmodule Xandra.Authenticator do
 
   To use the authenticator defined above:
 
-    Xandra.start_link(authentication: {MyAuthenticator, user: "my_user", password: "my_password"}
+    Xandra.start_link(authentication: {MyAuthenticator, user: "foo", password: "bar"})
 
   Xandra supports Cassandra's PasswordAuthenticator by default, see
   `Xandra.Authenticator.Password` for more information.

--- a/lib/xandra/authenticator.ex
+++ b/lib/xandra/authenticator.ex
@@ -1,0 +1,3 @@
+defmodule Xandra.Authenticator do
+  @callback response_body(Keyword.t) :: iodata
+end

--- a/lib/xandra/authenticator.ex
+++ b/lib/xandra/authenticator.ex
@@ -1,3 +1,27 @@
 defmodule Xandra.Authenticator do
+  @moduledoc """
+  A behaviour module for implementing a Cassandra authenticator
+
+  ## Example
+
+    defmodule MyAuthenticator do
+      @behaviour Xandra.Authenticator
+
+      def response_body(options) do
+        [Keyword.fetch(options, :foo), Keyword.fetch(options, :bar)]
+      end
+    end
+
+    # To use your authenticator
+
+    Xandra.start_link(authentication: {MyAuthenticator, foo: "foo", bar: "bar"}
+
+  Xandra supports Cassandra's PasswordAuthenticator by default, see
+  `Xandra.Authenticator.Password` for more information.
+  """
+
+  @doc """
+  Returns an IOdata that's used as the response body to Cassandra server's auth challenge
+  """
   @callback response_body(Keyword.t) :: iodata
 end

--- a/lib/xandra/authenticator/password.ex
+++ b/lib/xandra/authenticator/password.ex
@@ -5,13 +5,9 @@ defmodule Xandra.Authenticator.Password do
 
   ## Example
 
-    Xandra.start_link(
-      authentication: {
-        Xandra.Authenticator.Password,
-        username: "xandra",
-        password: "secret",
-      }
-    )
+    authentication_options = [username: "xandra", password: "secret"]
+    Xandra.start_link(authentication: {Xandra.Authenticator.Password, authentication_options})
+  
   """
   @behaviour Xandra.Authenticator
 

--- a/lib/xandra/authenticator/password.ex
+++ b/lib/xandra/authenticator/password.ex
@@ -1,0 +1,12 @@
+defmodule Xandra.Authenticator.Password do
+  @behaviour Xandra.Authenticator
+
+  def response_body(options) do
+    [
+      0x00,
+      Keyword.fetch!(options, :username),
+      0x00,
+      Keyword.fetch!(options, :password),
+    ]
+  end
+end

--- a/lib/xandra/authenticator/password.ex
+++ b/lib/xandra/authenticator/password.ex
@@ -5,9 +5,9 @@ defmodule Xandra.Authenticator.Password do
 
   ## Example
 
-    authentication_options = [username: "xandra", password: "secret"]
-    Xandra.start_link(authentication: {Xandra.Authenticator.Password, authentication_options})
-  
+    authenticator_options = [username: "xandra", password: "secret"]
+    Xandra.start_link(authentication: {Xandra.Authenticator.Password, authenticator_options})
+
   """
   @behaviour Xandra.Authenticator
 

--- a/lib/xandra/authenticator/password.ex
+++ b/lib/xandra/authenticator/password.ex
@@ -1,4 +1,18 @@
 defmodule Xandra.Authenticator.Password do
+  @moduledoc """
+  A `Xandra.Authenticator` that implements support for PasswordAuthenticator
+  to authenticate with Cassandra server.
+
+  ## Example
+
+    Xandra.start_link(
+      authentication: {
+        Xandra.Authenticator.Password,
+        username: "xandra",
+        password: "secret",
+      }
+    )
+  """
   @behaviour Xandra.Authenticator
 
   def response_body(options) do

--- a/lib/xandra/connection/utils.ex
+++ b/lib/xandra/connection/utils.ex
@@ -56,7 +56,7 @@ defmodule Xandra.Connection.Utils do
         %Frame{kind: :authenticate} ->
           authenticate_connection(socket, requested_options, compressor, options)
         _ ->
-          raise "protocol violation, got frame: #{inspect(frame)}"
+          raise "protocol violation, got unexpected frame: #{inspect(frame)}"
       end
     else
       {:error, reason} ->
@@ -75,7 +75,7 @@ defmodule Xandra.Connection.Utils do
       case frame do
         %Frame{kind: :auth_success} -> :ok
         %Frame{kind: :error} -> {:error, Protocol.decode_response(frame)}
-        _ -> raise "protocol violation, got frame: #{inspect(frame)}"
+        _ -> raise "protocol violation, got unexpected frame: #{inspect(frame)}"
       end
     else
       {:error, reason} ->

--- a/lib/xandra/frame.ex
+++ b/lib/xandra/frame.ex
@@ -20,6 +20,7 @@ defmodule Xandra.Frame do
     :execute => 0x0A,
     :register => 0x0B,
     :batch => 0x0D,
+    :auth_response => 0x0F,
   }
 
   @response_version 0x83
@@ -27,9 +28,11 @@ defmodule Xandra.Frame do
   @response_opcodes %{
     0x00 => :error,
     0x02 => :ready,
+    0x03 => :authenticate,
     0x06 => :supported,
     0x08 => :result,
     0x0C => :event,
+    0x10 => :auth_success,
   }
 
   @spec new(kind) :: t(kind) when kind: var

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -48,10 +48,10 @@ defmodule Xandra.Protocol do
              body <- authenticator.response_body(auth_options) do
           %{frame | body: [<<IO.iodata_length(body)::32>>, body]}
         else
-          _ -> raise ":authentication must be in {mod, mod_options} format"
+          _ -> raise "the :authentication option must be an {auth_module, auth_options} tuple, got: #{inspect(authentication)}"
         end
       :error ->
-        raise "Cassandra asked for authentication but you did not provide :authentication"
+        raise "Cassandra server requires authentication but the :authentication option was not provided"
     end
   end
 


### PR DESCRIPTION
Support Authentication in Xandra

* Respond to server's auth challenge
* Introduce Xandra.Authenticator behavior
* Support Password Authenticator through `Xandra.Authenticator.Password`

### API proposed

```ex
{:ok, conn} = Xandra.start_link(
  host: "127.0.0.1",
  port: 9042,
  authentication: {Xandra.Authenticator.Password, username: "cassandra", password: "cassandra"}
  ])
```
