### PR TITLE
Move date type starting point to Unix epoch

### DIFF
--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -6,6 +6,8 @@ defmodule Xandra.Protocol do
   alias Xandra.{Batch, Error, Frame, Prepared, Page, Simple, TypeParser}
   alias Xandra.Cluster.StatusChange
 
+  @unix_epoch_days 0x80000000
+
   # We need these two macros to make
   # a single match context possible.
 
@@ -309,8 +311,8 @@ defmodule Xandra.Protocol do
     <<value::64>>
   end
 
-  defp encode_value(:date, value) when value in 0..0xFFFFFFFF do
-    <<value::32>>
+  defp encode_value(:date, value) when value in -0x80000000..0x7FFFFFFF do
+    <<(value + @unix_epoch_days)::32>>
   end
 
   defp encode_value(:decimal, {value, scale}) do
@@ -611,7 +613,7 @@ defmodule Xandra.Protocol do
 
   defp decode_value(<<value::64-signed>>, :timestamp), do: value
 
-  defp decode_value(<<value::32>>, :date), do: value
+  defp decode_value(<<value::32>>, :date), do: (value - @unix_epoch_days)
 
   defp decode_value(<<value::32-signed>>, :int), do: value
 


### PR DESCRIPTION
I've spent some time investigating what the possible options to improve experience when working with dates and times are.

**1.** Accept and return `Date` structs.
  * Pros:
    * Native interoperability with `Date`
  * Cons:
    * Covers **very** limited slice of possible Cassandra dates (0000-01-01..9999-12-31 instead of -5877641-06-23..5881580-07-11)

**2.** Introduce `Xandra.Date` struct together with helper functions for converting to/from `Date`
  * Pros:
    * Supports full range of Cassandra dates
  * Cons:
    * Requires constant transformations to/from `Date` for later processing, also needs some extra logic in `Xandra.Date` (for instance, implementation  of the `Inspect` protocol)

**3.** Move 0 date to some more expected point in time (Unix epoch)
  * Pros:
    * Supports full range of Cassandra dates
    * Makes transformations to/from `Date` much easier than with **2.**
      
      * `Date.diff(date, ~D[1970-01-01])` – when writing data
      * `Date.add(~D[1970-01-01], date)` – when reading data

CC @aphillipo @jeremytregunna