### PR TITLE
Fix parsing of ping frames when compressed

### DIFF
--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -88,8 +88,8 @@ defmodule Xandra.Connection do
     :ok = :gen_tcp.close(socket)
   end
 
-  def ping(%__MODULE__{socket: socket} = state) do
-    case Utils.request_options(socket) do
+  def ping(%__MODULE__{socket: socket, compressor: compressor} = state) do
+    case Utils.request_options(socket, compressor) do
       {:ok, _options} ->
         {:ok, state}
       {:error, %ConnectionError{reason: reason}} ->

--- a/lib/xandra/connection/utils.ex
+++ b/lib/xandra/connection/utils.ex
@@ -19,15 +19,15 @@ defmodule Xandra.Connection.Utils do
     end
   end
 
-  @spec request_options(:gen_tcp.socket) :: {:ok, term} | {:error, ConnectionError.t}
-  def request_options(socket) do
+  @spec request_options(:gen_tcp.socket, nil | module) :: {:ok, term} | {:error, ConnectionError.t}
+  def request_options(socket, compressor \\ nil) do
     payload =
       Frame.new(:options)
       |> Protocol.encode_request(nil)
       |> Frame.encode()
 
     with :ok <- :gen_tcp.send(socket, payload),
-         {:ok, %Frame{} = frame} <- recv_frame(socket) do
+         {:ok, %Frame{} = frame} <- recv_frame(socket, compressor) do
       {:ok, Protocol.decode_response(frame)}
     else
       {:error, reason} ->


### PR DESCRIPTION
Fixes #116 by passing the the value of compressor (held in state) to `Xandra.Connection.Utils.request_options/2`