### PR TITLE
Fix missing alias for ConnectionError

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -154,7 +154,7 @@ defmodule Xandra do
   passed, the outgoing data will not be compressed.
   """
 
-  alias __MODULE__.{Batch, Connection, Error, Prepared, Page, PageStream, Simple}
+  alias __MODULE__.{Batch, Connection, ConnectionError, Error, Prepared, Page, PageStream, Simple}
 
   @type statement :: String.t
   @type values :: list | map


### PR DESCRIPTION
`ConnectionError` is used in  `@type error :: Error.t | ConnectionError.t` (see [`xandra.ex`][1]), but not aliased at the top of the module. 

This results in dialyzer reporting an unknown type (`Unknown type 'Elixir.ConnectionError':t/0`) and also in a missing link in the [documentation for `t:Xandra.error/0`](https://hexdocs.pm/xandra/Xandra.html#t:error/0).

The PR adds an alias for `ConnectionError`.

[1]: https://github.com/lexhide/xandra/blob/70286b118fa17f6b3a436e4f7e3ac0ac451c868a/lib/xandra.ex#L161