### PR TITLE
Require Elixir ~> 1.4 and fix warnings on the codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ otp_release:
   - 19.2
 
 elixir:
-  - 1.3.4
+  - 1.4.5
   - 1.7.3
 
 env:

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -408,7 +408,7 @@ defmodule Xandra.Protocol do
   end
 
   defp encode_value(:timestamp, %DateTime{} = value) do
-    <<DateTime.to_unix(value, :milliseconds)::64>>
+    <<DateTime.to_unix(value, :millisecond)::64>>
   end
 
   defp encode_value(:timestamp, value) when is_integer(value) do
@@ -711,7 +711,7 @@ defmodule Xandra.Protocol do
 
   defp decode_value(<<value::64-signed>>, {:timestamp, [format]}) do
     case format do
-      :datetime -> DateTime.from_unix!(value, :milliseconds)
+      :datetime -> DateTime.from_unix!(value, :millisecond)
       :integer -> value
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule Xandra.Mixfile do
     [
       app: :xandra,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/integration/batch_test.exs
+++ b/test/integration/batch_test.exs
@@ -56,7 +56,7 @@ defmodule BatchTest do
   end
 
   test "using a default timestamp for the batch", %{conn: conn} do
-    timestamp = System.system_time(:seconds) - (_10_minutes = 600)
+    timestamp = System.system_time(:second) - (_10_minutes = 600)
 
     batch =
       Batch.new()


### PR DESCRIPTION
* We can stop using `Collectable` on non-empty list as the semantics don't change at all
* We can safely use `:millisecond` and `:second` (over `:milliseconds` and `:seconds`) since they're supported at least since 1.4