### PR TITLE
Use Docker for testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ stages:
 
 # These steps are taken from: http://cassandra.apache.org/doc/latest/getting_started/installing.html#installation-from-binary-tarball-files.
 before_install:
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m) > docker-compose
   - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
   - docker-compose build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: elixir
 dist: trusty
 sudo: required
 
+services:
+  - docker
+
 otp_release:
   - 19.2
 
@@ -11,10 +14,13 @@ elixir:
   - 1.7.3
 
 env:
-  - CASSANDRA_VERSION=2.2.8 AUTHENTICATION=true
-  - CASSANDRA_VERSION=2.2.8
-  - CASSANDRA_VERSION=3.9 AUTHENTICATION=true
-  - CASSANDRA_VERSION=3.9
+  global:
+    - DOCKER_COMPOSE_VERSION=1.22.0
+  matrix:
+    - CASSANDRA_VERSION=2.2 AUTHENTICATION=true
+    - CASSANDRA_VERSION=2.2
+    - CASSANDRA_VERSION=3 AUTHENTICATION=true
+    - CASSANDRA_VERSION=3
 
 script:
   - mix test
@@ -34,12 +40,7 @@ stages:
 
 # These steps are taken from: http://cassandra.apache.org/doc/latest/getting_started/installing.html#installation-from-binary-tarball-files.
 before_install:
-  - java -version
-  - wget https://archive.apache.org/dist/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz
-  - tar -xzf apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz
-  - |-
-    if [ $AUTHENTICATION = true ]; then
-      sed -i -e "s/\(authenticator: \)AllowAllAuthenticator/\1PasswordAuthenticator/" apache-cassandra-$CASSANDRA_VERSION/conf/cassandra.yaml
-    fi
-  - sh apache-cassandra-$CASSANDRA_VERSION/bin/cassandra
-  - for try in {1..12}; do (nodetool version > /dev/null 2>&1 && break) || sleep 5; done
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - docker-compose build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - CASSANDRA_VERSION=3
 
 script:
-  - docker-compose up --detach
+  - docker-compose up -d
   - ./test/docker/wait-for-cassandra.sh
   - mix test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
     - CASSANDRA_VERSION=3
 
 script:
+  - docker-compose up --detach
+  - ./test/docker/wait-for-cassandra.sh
   - mix test
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ To run tests, you need Cassandra running on your machine on port `9042`. You can
     docker-compose up
     ```
 
+Once you have Cassandra running (one way or the other), run `$ mix test` to run tests.
+
 ## License
 
 Xandra is released under the ISC license, see the [LICENSE](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,16 @@ page_stream
 
 ## Contributing
 
-Clone the repository and run `$ mix test` to make sure your setup is correct; you're going to need Cassandra running locally on its default port (`9042`) for tests to pass.
+To run tests, you need Cassandra running on your machine on port `9042`. You can:
+
+  * install Cassandra and run it locally
+
+  * use [Docker][docker] to run a Cassandra container locally. If you choose this way, you only
+    need to have Docker installed. To run the test setup, just run:
+
+    ```bash
+    docker-compose up
+    ```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ Xandra is released under the ISC license, see the [LICENSE](LICENSE) file.
 [documentation]: https://hexdocs.pm/xandra
 [cassandra]: http://cassandra.apache.org
 [production-use]: http://tech.forzafootball.com/blog/the-pursuit-of-instant-pushes
+[docker]: https://www.docker.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  cassandra:
+    build:
+      context: ./test/docker
+      dockerfile: Dockerfile.cassandra
+      args:
+        - CASSANDRA_VERSION
+        - AUTHENTICATION
+    ports:
+      - "9042:9042"

--- a/test/docker/Dockerfile.cassandra
+++ b/test/docker/Dockerfile.cassandra
@@ -1,0 +1,12 @@
+ARG CASSANDRA_VERSION=latest
+
+FROM cassandra:$CASSANDRA_VERSION
+
+ARG AUTHENTICATION=false
+
+RUN echo $CASSANDRA_VERSION
+RUN echo $AUTHENTICATION
+
+RUN if [ "$AUTHENTICATION" = true ]; then \
+      sed -i -e "s/\(authenticator: \)AllowAllAuthenticator/\1PasswordAuthenticator/" /etc/cassandra/cassandra.yaml; \
+    fi

--- a/test/docker/wait-for-cassandra.sh
+++ b/test/docker/wait-for-cassandra.sh
@@ -5,7 +5,7 @@ set -e
 MAX_TRIES=12
 
 function cassandra-is-ready() {
-  docker-compose logs cassandra | grep "Starting listening for CQL clients" >/dev/null
+  docker-compose logs cassandra | grep "Starting listening for CQL clients" > /dev/null
 }
 
 function wait-until-cassandra-is-ready() {

--- a/test/docker/wait-for-cassandra.sh
+++ b/test/docker/wait-for-cassandra.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Max query attempts before consider setup failed
+MAX_TRIES=12
+
+function cassandra-is-ready() {
+  docker-compose logs cassandra | grep "Starting listening for CQL clients" >/dev/null
+}
+
+function wait-until-cassandra-is-ready() {
+  attempt=1
+
+  while [ $attempt -le $MAX_TRIES ]; do
+    if cassandra-is-ready; then
+      echo "Cassandra is up and running"
+      break
+    fi
+
+    sleep 3
+  done
+
+  if [ $attempt -gt $MAX_TRIES ]; then
+    echo "Cassandra not responding, cancelling set up"
+    exit 1
+  fi
+}
+
+wait-until-cassandra-is-ready


### PR DESCRIPTION
This PR adds support for a Docker environment which sets up all the necessary infrastructure (Cassandra) to run tests. Tests are still run outside of Docker with `mix test`, Docker is only used for setting up Cassandra.

We are using `docker-compose` to spin up Cassandra (foreseeing a future where we could also spin up ScyllaDB in the same way). This means you only need to run `docker-compose up` to spin up the whole testing environment.

The reasons for this PR are two: first of all we can run tests without installing the whole Cassandra package (and eventually ScyllaDB) in an easy and reproducible way. Then, we can do exactly the same on Travis CI.