### PR TITLE
Migrate to db_connection ~2.0

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -217,10 +217,6 @@ defmodule Xandra do
 
       Xandra.start_link(pool: DBConnection.ConnectionPool)
 
-  Note that this requires the `poolboy` dependency to be specified in your
-  application. The following options have default values that are different from
-  the default values provided by `DBConnection`:
-
     * `:idle_interval` - defaults to `30_000` (30 seconds)
 
   ## Examples

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -17,7 +17,7 @@ defmodule Xandra.Cluster do
   in the specified list of nodes (used for internal purposes).
 
   Here is an example of how one could use `Xandra.Cluster` to connect to
-  multiple nodes, while using `:poolboy` for pooling the connections to each
+  multiple nodes, while using `DBConnection.ConnectionPool` for pooling the connections to each
   node:
 
       Xandra.start_link([

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Xandra.Mixfile do
 
   defp deps() do
     [
-      {:db_connection, "~> 1.0"},
+      {:db_connection, "~> 2.0"},
       {:snappy, github: "skunkwerks/snappy-erlang-nif", only: [:dev, :test]},
       {:ex_doc, "~> 0.14", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.0.5", "ddb2ba6761a08b2bb9ca0e7d260e8f4dd39067426d835c24491a321b7f92a4da", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "snappy": {:git, "https://github.com/skunkwerks/snappy-erlang-nif.git", "0951a1bf8e58141b3c439bebe1f2992688298631", []},

--- a/test/integration/batch_test.exs
+++ b/test/integration/batch_test.exs
@@ -29,9 +29,9 @@ defmodule BatchTest do
       |> Batch.add("INSERT INTO users (id, name) VALUES (?, ?)", [{"int", 3}, {"text", "Lisa"}])
       |> Batch.add("DELETE FROM users WHERE id = ?", [{"int", 3}])
 
-    assert {:ok, %Void{}} = Xandra.execute(conn, batch)
+    assert {:ok, %Batch{}, %Void{}} = Xandra.execute(conn, batch)
 
-    {:ok, result} = Xandra.execute(conn, "SELECT name FROM users")
+    {:ok, _batch, result} = Xandra.execute(conn, "SELECT name FROM users")
 
     assert Enum.to_list(result) == [
              %{"name" => "Marge"},
@@ -45,7 +45,7 @@ defmodule BatchTest do
       |> Batch.add("INSERT INTO users (id, name) VALUES (1, 'Rick')")
       |> Batch.add("INSERT INTO users (id, name) VALUES (2, 'Morty')")
 
-    assert {:ok, %Void{}} = Xandra.execute(conn, batch)
+    assert {:ok, %Batch{}, %Void{}} = Xandra.execute(conn, batch)
 
     result = Xandra.execute!(conn, "SELECT name FROM users")
 
@@ -63,7 +63,7 @@ defmodule BatchTest do
       |> Batch.add("INSERT INTO users (id, name) VALUES (1, 'Abed')")
       |> Batch.add("INSERT INTO users (id, name) VALUES (2, 'Troy')")
 
-    assert {:ok, %Void{}} = Xandra.execute(conn, batch, timestamp: timestamp)
+    assert {:ok, %Batch{}, %Void{}} = Xandra.execute(conn, batch, timestamp: timestamp)
 
     result = Xandra.execute!(conn, "SELECT name, WRITETIME(name) FROM users")
 
@@ -87,7 +87,7 @@ defmodule BatchTest do
 
     batch = Batch.add(Batch.new(), prepared_insert, %{"id" => 1, "name" => "Beth"})
 
-    assert {:ok, %Void{}} = Xandra.execute(conn, batch)
+    assert {:ok, %Batch{}, %Void{}} = Xandra.execute(conn, batch)
 
     result = Xandra.execute!(conn, "SELECT name FROM users WHERE id = 1")
 
@@ -117,7 +117,7 @@ defmodule BatchTest do
   end
 
   test "empty batch", %{conn: conn} do
-    assert {:ok, %Void{}} = Xandra.execute(conn, Batch.new())
+    assert {:ok, %Batch{}, %Void{}} = Xandra.execute(conn, Batch.new())
   end
 
   test "inspecting batch queries", %{conn: conn} do

--- a/test/integration/clustering_test.exs
+++ b/test/integration/clustering_test.exs
@@ -26,7 +26,8 @@ defmodule ClusteringTest do
         start_options = [
           nodes: ["127.0.0.1", "127.0.0.1", "127.0.0.2"],
           name: TestCluster,
-          load_balancing: :random
+          load_balancing: :random,
+          underlying_pool: DBConnection.ConnectionPool
         ]
 
         {:ok, cluster} = Xandra.start_link(call_options ++ start_options)

--- a/test/integration/compression_test.exs
+++ b/test/integration/compression_test.exs
@@ -31,18 +31,23 @@ defmodule CompressionTest do
 
     # We check that sending a non-compressed request which will receive a
     # compressed response works.
-    assert {:ok, %Xandra.Page{} = page} = Xandra.execute(compressed_conn, statement, [{"int", 1}])
+    assert {:ok, %Xandra.Simple{}, %Xandra.Page{} = page} =
+             Xandra.execute(compressed_conn, statement, [{"int", 1}])
+
     assert Enum.to_list(page) == [%{"code" => 1, "name" => "Homer"}]
 
     # Compressing simple queries.
-    assert {:ok, %Xandra.Page{} = page} =
+    assert {:ok, %Xandra.Simple{}, %Xandra.Page{} = page} =
              Xandra.execute(compressed_conn, statement, [{"int", 1}], options)
 
     assert Enum.to_list(page) == [%{"code" => 1, "name" => "Homer"}]
 
     # Compressing preparing queries and executing prepared queries.
     assert {:ok, prepared} = Xandra.prepare(compressed_conn, statement, options)
-    assert {:ok, %Xandra.Page{} = page} = Xandra.execute(compressed_conn, prepared, [1], options)
+
+    assert {:ok, ^prepared, %Xandra.Page{} = page} =
+             Xandra.execute(compressed_conn, prepared, [1], options)
+
     assert Enum.to_list(page) == [%{"code" => 1, "name" => "Homer"}]
 
     # This sleep is needed to test pings with compression,
@@ -55,6 +60,6 @@ defmodule CompressionTest do
       |> Xandra.Batch.add("INSERT INTO #{keyspace}.users (code, name) VALUES (2, 'Marge')")
       |> Xandra.Batch.add("DELETE FROM #{keyspace}.users WHERE code = ?", [{"int", 1}])
 
-    assert {:ok, %Xandra.Void{}} = Xandra.execute(compressed_conn, batch, options)
+    assert {:ok, ^batch, %Xandra.Void{}} = Xandra.execute(compressed_conn, batch, options)
   end
 end

--- a/test/integration/paging_test.exs
+++ b/test/integration/paging_test.exs
@@ -35,7 +35,7 @@ defmodule PagingTest do
 
     options = [page_size: 3]
 
-    assert {:ok, %Page{paging_state: paging_state} = page} =
+    assert {:ok, ^query, %Page{paging_state: paging_state} = page} =
              Xandra.execute(conn, query, [], options)
 
     assert Enum.to_list(page) == [
@@ -48,7 +48,7 @@ defmodule PagingTest do
 
     options = [page_size: 2, paging_state: paging_state]
 
-    assert {:ok, %Page{paging_state: paging_state} = page} =
+    assert {:ok, ^query, %Page{paging_state: paging_state} = page} =
              Xandra.execute(conn, query, [], options)
 
     assert Enum.to_list(page) == [
@@ -60,7 +60,7 @@ defmodule PagingTest do
 
     options = [page_size: 6, paging_state: paging_state]
 
-    assert {:ok, %Page{paging_state: paging_state} = page} =
+    assert {:ok, ^query, %Page{paging_state: paging_state} = page} =
              Xandra.execute(conn, query, [], options)
 
     assert Enum.count(page) == 5

--- a/test/integration/prepared_test.exs
+++ b/test/integration/prepared_test.exs
@@ -31,7 +31,7 @@ defmodule PreparedTest do
     # Successive call to prepare uses cache.
     assert {:ok, ^prepared} = Xandra.prepare(conn, statement)
 
-    assert {:ok, page} = Xandra.execute(conn, prepared, [1])
+    assert {:ok, ^prepared, page} = Xandra.execute(conn, prepared, [1])
 
     assert Enum.to_list(page) == [
              %{"name" => "Homer"},
@@ -39,13 +39,13 @@ defmodule PreparedTest do
              %{"name" => "Marge"}
            ]
 
-    assert {:ok, page} = Xandra.execute(conn, prepared, %{"code" => 2})
+    assert {:ok, ^prepared, page} = Xandra.execute(conn, prepared, %{"code" => 2})
 
     assert Enum.to_list(page) == [
              %{"name" => "Moe"}
            ]
 
-    assert {:ok, page} = Xandra.execute(conn, prepared, %{"code" => 5})
+    assert {:ok, ^prepared, page} = Xandra.execute(conn, prepared, %{"code" => 5})
     assert Enum.to_list(page) == []
   end
 
@@ -53,10 +53,10 @@ defmodule PreparedTest do
     statement = "INSERT INTO users (code, name) VALUES (3, 'Nelson') IF NOT EXISTS"
     assert {:ok, prepared} = Xandra.prepare(conn, statement)
 
-    assert {:ok, page} = Xandra.execute(conn, prepared)
+    assert {:ok, ^prepared, page} = Xandra.execute(conn, prepared)
     assert Enum.to_list(page) == [%{"[applied]" => true}]
 
-    assert {:ok, page} = Xandra.execute(conn, prepared)
+    assert {:ok, ^prepared, page} = Xandra.execute(conn, prepared)
     assert Enum.to_list(page) == [%{"[applied]" => false, "code" => 3, "name" => "Nelson"}]
   end
 

--- a/test/integration/results_test.exs
+++ b/test/integration/results_test.exs
@@ -1,14 +1,14 @@
 defmodule ResultsTest do
   use XandraTest.IntegrationCase, async: true
 
-  alias Xandra.{SchemaChange, SetKeyspace, Void}
+  alias Xandra.{SchemaChange, SetKeyspace, Void, Simple}
 
   test "each possible result", %{conn: conn, keyspace: keyspace} do
-    assert {:ok, result} = Xandra.execute(conn, "USE #{keyspace}")
+    assert {:ok, %Simple{}, result} = Xandra.execute(conn, "USE #{keyspace}")
     assert result == %SetKeyspace{keyspace: String.downcase(keyspace)}
 
     statement = "CREATE TABLE numbers (figure int PRIMARY KEY)"
-    assert {:ok, result} = Xandra.execute(conn, statement)
+    assert {:ok, %Simple{}, result} = Xandra.execute(conn, statement)
 
     assert result == %SchemaChange{
              effect: "CREATED",
@@ -20,18 +20,18 @@ defmodule ResultsTest do
            }
 
     statement = "INSERT INTO numbers (figure) VALUES (123)"
-    assert {:ok, result} = Xandra.execute(conn, statement)
+    assert {:ok, %Simple{}, result} = Xandra.execute(conn, statement)
     assert result == %Void{}
 
     statement = "SELECT * FROM numbers WHERE figure = ?"
-    assert {:ok, result} = Xandra.execute(conn, statement, [{"int", 123}])
+    assert {:ok, %Simple{}, result} = Xandra.execute(conn, statement, [{"int", 123}])
     assert Enum.to_list(result) == [%{"figure" => 123}]
 
-    assert {:ok, result} = Xandra.execute(conn, statement, [{"int", 321}])
+    assert {:ok, %Simple{}, result} = Xandra.execute(conn, statement, [{"int", 321}])
     assert Enum.to_list(result) == []
 
     statement = "SELECT * FROM numbers WHERE figure = :figure"
-    assert {:ok, result} = Xandra.execute(conn, statement, %{"figure" => {"int", 123}})
+    assert {:ok, %Simple{}, result} = Xandra.execute(conn, statement, %{"figure" => {"int", 123}})
     assert Enum.to_list(result) == [%{"figure" => 123}]
   end
 


### PR DESCRIPTION
Since db_connection 2.0 now provides only `DBConnection.ConnectionPool`, I removed `underlying_pool` from options and simplified `Xandra.Cluster`. 

Now Xandra.Connection has some warnings:
```
Compiling 25 files (.ex)
warning: function handle_begin/2 required by behaviour DBConnection is not implemented (in module Xandra.Connection)
  lib/xandra/connection.ex:1

warning: function handle_commit/2 required by behaviour DBConnection is not implemented (in module Xandra.Connection)
  lib/xandra/connection.ex:1

warning: function handle_deallocate/4 required by behaviour DBConnection is not implemented (in module Xandra.Connection)
  lib/xandra/connection.ex:1

warning: function handle_declare/4 required by behaviour DBConnection is not implemented (in module Xandra.Connection)
  lib/xandra/connection.ex:1

warning: function handle_fetch/4 required by behaviour DBConnection is not implemented (in module Xandra.Connection)
  lib/xandra/connection.ex:1

warning: function handle_rollback/2 required by behaviour DBConnection is not implemented (in module Xandra.Connection)
  lib/xandra/connection.ex:1
```

I'm trying to figure out it myself, but I'm not really sure how to implement them.