### PR TITLE
Rework a bunch of stuff to upgrade to DBConnection ~> 2.0

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -255,7 +255,7 @@ defmodule Xandra do
   run for every established connection, it will work well with pools as well.
 
       after_connect_fun = fn conn ->
-        Xandra.execute(conn, "USE my_keyspace")
+        Xandra.execute!(conn, "USE my_keyspace")
       end
 
       {:ok, conn} = Xandra.start_link(after_connect: after_connect_fun)

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -930,19 +930,14 @@ defmodule Xandra do
   end
 
   defp parse_start_options(options) do
-    cluster? = options[:pool] == Xandra.Cluster
-
     Enum.flat_map(options, fn
-      {:nodes, nodes} when cluster? ->
-        [nodes: Enum.map(nodes, &parse_node/1)]
-
       {:nodes, [string]} ->
         {address, port} = parse_node(string)
         [address: address, port: port]
 
       {:nodes, _nodes} ->
         raise ArgumentError,
-              "multi-node use requires the :pool option to be set to Xandra.Cluster"
+              "multi-node use requires Xandra.Cluster instead of Xandra"
 
       {_key, _value} = option ->
         [option]

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -234,13 +234,7 @@ defmodule Xandra.Cluster do
 
     options = Keyword.merge(options, address: address, port: port)
 
-    child_spec = %{
-      id: address,
-      start: {Xandra, :start_link, [options]},
-      type: :worker
-    }
-
-    case Supervisor.start_child(pool_supervisor, child_spec) do
+    case Supervisor.start_child(pool_supervisor, {Xandra, options}) do
       {:ok, pool} ->
         node_refs = List.keystore(node_refs, node_ref, 0, {node_ref, address})
         %{state | node_refs: node_refs, pools: Map.put(pools, address, pool)}

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -51,13 +51,11 @@ defmodule Xandra.Cluster.ControlConnection do
           {:ok, state}
         else
           {:error, _reason} = error ->
-            IO.inspect(error, label: "error in CC.connect")
             {:connect, :reconnect, state} = disconnect(error, state)
             {:backoff, @default_backoff, state}
         end
 
       {:error, reason} ->
-        IO.inspect(reason, label: "couldn't connect to #{address}:#{port}")
         {:backoff, @default_backoff, state}
     end
   end

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -51,11 +51,13 @@ defmodule Xandra.Cluster.ControlConnection do
           {:ok, state}
         else
           {:error, _reason} = error ->
+            IO.inspect(error, label: "error in CC.connect")
             {:connect, :reconnect, state} = disconnect(error, state)
             {:backoff, @default_backoff, state}
         end
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        IO.inspect(reason, label: "couldn't connect to #{address}:#{port}")
         {:backoff, @default_backoff, state}
     end
   end

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -55,7 +55,7 @@ defmodule Xandra.Cluster.ControlConnection do
             {:backoff, @default_backoff, state}
         end
 
-      {:error, reason} ->
+      {:error, _reason} ->
         {:backoff, @default_backoff, state}
     end
   end

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -58,8 +58,9 @@ defmodule Xandra.Connection do
   end
 
   @impl true
-  def handle_status(_opts, _state) do
-    raise ArgumentError, "Cassandra doesn't support transactions"
+  def handle_status(_opts, state) do
+    # :idle means we're not in a transaction.
+    {:idle, state}
   end
 
   @impl true
@@ -121,7 +122,7 @@ defmodule Xandra.Connection do
   @impl true
   def handle_execute(query, payload, options, %__MODULE__{} = state) do
     %{socket: socket, compressor: compressor, atom_keys?: atom_keys?} = state
-    compressor = assert_valid_compressor(compressor, options[:compressor])
+    assert_valid_compressor(compressor, options[:compressor])
 
     with :ok <- :gen_tcp.send(socket, payload),
          {:ok, %Frame{} = frame} <- Utils.recv_frame(socket, compressor) do

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -11,6 +11,7 @@ defmodule Xandra.Connection do
 
   defstruct [:socket, :prepared_cache, :compressor, :atom_keys?]
 
+  @impl true
   def connect(options) do
     address = Keyword.fetch!(options, :address)
     port = Keyword.fetch!(options, :port)
@@ -41,14 +42,52 @@ defmodule Xandra.Connection do
     end
   end
 
+  @impl true
+  def handle_begin(_opts, _state) do
+    raise ArgumentError, "Cassandra doesn't support transactions"
+  end
+
+  @impl true
+  def handle_commit(_opts, _state) do
+    raise ArgumentError, "Cassandra doesn't support transactions"
+  end
+
+  @impl true
+  def handle_rollback(_opts, _state) do
+    raise ArgumentError, "Cassandra doesn't support transactions"
+  end
+
+  @impl true
+  def handle_status(_opts, _state) do
+    raise ArgumentError, "Cassandra doesn't support transactions"
+  end
+
+  @impl true
+  def handle_declare(_query, _params, _opts, _state) do
+    raise ArgumentError, "Cassandra doesn't support cursors"
+  end
+
+  @impl true
+  def handle_deallocate(_query, _cursor, _opts, _state) do
+    raise ArgumentError, "Cassandra doesn't support cursors"
+  end
+
+  @impl true
+  def handle_fetch(_query, _cursor, _opts, _state) do
+    raise ArgumentError, "Cassandra doesn't support cursors"
+  end
+
+  @impl true
   def checkout(state) do
     {:ok, state}
   end
 
+  @impl true
   def checkin(state) do
     {:ok, state}
   end
 
+  @impl true
   def handle_prepare(%Prepared{} = prepared, options, %__MODULE__{socket: socket} = state) do
     force? = Keyword.get(options, :force, false)
     compressor = assert_valid_compressor(state.compressor, options[:compressor])
@@ -79,27 +118,31 @@ defmodule Xandra.Connection do
     end
   end
 
-  def handle_execute(_query, payload, options, %__MODULE__{} = state) do
+  @impl true
+  def handle_execute(query, payload, options, %__MODULE__{} = state) do
     %{socket: socket, compressor: compressor, atom_keys?: atom_keys?} = state
-    assert_valid_compressor(compressor, options[:compressor])
+    compressor = assert_valid_compressor(compressor, options[:compressor])
 
     with :ok <- :gen_tcp.send(socket, payload),
          {:ok, %Frame{} = frame} <- Utils.recv_frame(socket, compressor) do
-      {:ok, %{frame | atom_keys?: atom_keys?}, state}
+      {:ok, query, %{frame | atom_keys?: atom_keys?}, state}
     else
       {:error, reason} ->
         {:disconnect, ConnectionError.new("execute", reason), state}
     end
   end
 
+  @impl true
   def handle_close(query, _options, state) do
     {:ok, query, state}
   end
 
+  @impl true
   def disconnect(_exception, %__MODULE__{socket: socket}) do
     :ok = :gen_tcp.close(socket)
   end
 
+  @impl true
   def ping(%__MODULE__{socket: socket, compressor: compressor} = state) do
     case Utils.request_options(socket, compressor) do
       {:ok, _options} ->
@@ -175,7 +218,7 @@ defmodule Xandra.Connection do
             "a query was compressed with the #{inspect(provided)} compressor module " <>
               "(which uses the #{inspect(provided_algorithm)} algorithm) but the " <>
               "connection was initialized with the #{inspect(initial)} compressor " <>
-              "module (which uses the #{inspect(initial_algorithm)}"
+              "module (which uses the #{inspect(initial_algorithm)} algorithm)"
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Xandra.Mixfile do
 
   defp deps() do
     [
-      {:db_connection, "~> 1.0"},
+      {:db_connection, "~> 2.0"},
       {:snappy, github: "skunkwerks/snappy-erlang-nif", only: [:dev, :test]},
       {:ex_doc, "~> 0.20", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.0.6", "bde2f85d047969c5b5800cb8f4b3ed6316c8cb11487afedac4aa5f93fd39abfa", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/integration/authentication_test.exs
+++ b/test/integration/authentication_test.exs
@@ -7,13 +7,11 @@ defmodule AuthenticationTest do
   @moduletag :authentication
 
   test "challenge is passed", %{keyspace: keyspace, start_options: start_options} do
-    call_options = [pool: Xandra.Cluster]
-
-    {:ok, cluster} = Xandra.start_link(call_options ++ start_options)
+    {:ok, cluster} = Xandra.Cluster.start_link(start_options)
 
     assert ClusteringTest.await_connected(
              cluster,
-             call_options,
+             _options = [],
              &Xandra.execute!(&1, "USE #{keyspace}")
            )
   end

--- a/test/xandra_test.exs
+++ b/test/xandra_test.exs
@@ -8,7 +8,7 @@ defmodule XandraTest do
       Xandra.start_link(nodes: ["foo:bar"])
     end
 
-    message = "multi-node use requires the :pool option to be set to Xandra.Cluster"
+    message = "multi-node use requires Xandra.Cluster instead of Xandra"
 
     assert_raise ArgumentError, message, fn ->
       Xandra.start_link(nodes: ["foo", "bar"])
@@ -17,7 +17,7 @@ defmodule XandraTest do
     message = "invalid item \"bar:baz\" in the :nodes option"
 
     assert_raise ArgumentError, message, fn ->
-      Xandra.start_link(nodes: ["foo", "bar:baz"], pool: Xandra.Cluster)
+      Xandra.start_link(nodes: ["bar:baz"])
     end
   end
 end


### PR DESCRIPTION
Closes #132.

* We dropped support for custom pools. Now `Xandra` uses `DBConnection.ConnectionPool` under the hood.
* We raise on every transaction-related or cursor-related DBConnection callback.
* We changed `Xandra.Cluster` to be its own process with an API that mirrors `Xandra` instead of being a custom pool.