### PR TITLE
Fix invocation of encryption test in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
 
     - &test-encrypted
       stage: test encrypted
-      script: mix test --only encrypted
+      script: mix test --only encryption
       before_script:
         - docker-compose --file docker-compose.yml --file docker-compose.cassandra-encrypted.yml up -d
         - ./test/docker/health-check-services.sh


### PR DESCRIPTION
The test is tagged as `:encryption` (see [encryption_test.exs]) but Travis CI tries to run `--only encrypted` (see [.travis.yml]).

[encryption_test.exs]: https://github.com/lexhide/xandra/blob/2e79eeb4dc4f6ed22d808cac99b17d2879a79bfd/test/integration/encryption_test.exs
[.travis.yml]: https://github.com/lexhide/xandra/blob/2e79eeb4dc4f6ed22d808cac99b17d2879a79bfd/.travis.yml