### PR TITLE
Encode queries after state checkout

### DIFF
--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -98,10 +98,7 @@ defmodule Xandra.Batch do
 
     def encode(batch, nil, options) do
       batch = %{batch | queries: Enum.reverse(batch.queries)}
-
-      Frame.new(:batch)
-      |> Protocol.encode_request(batch, options)
-      |> Frame.encode(options[:compressor])
+      {Frame.new(:batch), batch}
     end
 
     def decode(batch, %Frame{} = frame, _options) do

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -41,9 +41,7 @@ defmodule Xandra.Prepared do
     end
 
     def encode(prepared, values, options) when is_list(values) do
-      Frame.new(:execute)
-      |> Protocol.encode_request(%{prepared | values: values}, options)
-      |> Frame.encode(options[:compressor])
+      {Frame.new(:execute), %{prepared | values: values}}
     end
 
     def decode(prepared, %Frame{} = frame, options) do

--- a/lib/xandra/simple.ex
+++ b/lib/xandra/simple.ex
@@ -16,9 +16,7 @@ defmodule Xandra.Simple do
     end
 
     def encode(query, values, options) do
-      Frame.new(:query)
-      |> Protocol.encode_request(%{query | values: values}, options)
-      |> Frame.encode(options[:compressor])
+      {Frame.new(:query), %{query | values: values}}
     end
 
     def decode(query, %Frame{} = frame, options) do


### PR DESCRIPTION
Postgrex does the same in https://github.com/elixir-ecto/postgrex/blob/53e0090d929dbacd42d424a8d09f001f070df777/lib/postgrex/query.ex#L55-L69.

## Benchmarks

Using this benchmark code: 

<details>

```elixir
{:ok, c} = Xandra.start_link()

Process.sleep(1000)

execute_once = fn ->
  Xandra.execute(c, "USE tests")
end

execute_100 = fn ->
  Enum.each(1..100, fn _ -> Xandra.execute(c, "USE tests") end)
end

execute_50_parallel = fn ->
  1..30
  |> Task.async_stream(fn _ ->
    Enum.each(1..80, fn _ -> Xandra.execute(c, "USE tests") end)
  end)
  |> Stream.run()
end

benches = %{
  "execute once" => execute_once,
  "execute 100" => execute_100,
  "execute 30/80 parallel" => execute_50_parallel
}

Benchee.run(benches, time: 10, memory_time: 2)
```

</details>

Before this PR:

```
Name                             ips        average  deviation         median         99th %
execute once                  920.89        1.09 ms    ±71.88%        0.99 ms        2.19 ms
execute 100                    10.30       97.13 ms    ±18.50%       91.84 ms      167.56 ms
execute 30/80 parallel          0.38     2599.49 ms    ±10.91%     2715.63 ms     2789.17 ms
```

After this PR:

```
Name                             ips        average  deviation         median         99th %
execute once                  891.82        1.12 ms   ±177.20%        1.03 ms        2.32 ms
execute 100                    10.32       96.93 ms     ±7.54%       96.08 ms      127.15 ms
execute 30/80 parallel          0.38     2615.08 ms     ±8.48%     2633.58 ms     2857.95 ms
```

Also, throwing in @jvf's solution in #144:

```
Name                             ips        average  deviation         median         99th %
execute once                 1061.57      0.00094 s    ±96.93%      0.00091 s      0.00143 s
execute 100                     8.83        0.113 s    ±34.16%       0.0988 s         0.40 s
execute 30/80 parallel          0.45         2.20 s     ±4.34%         2.21 s         2.32 s
```

No memory usage changes. Seems like we gain some speedup too.