### PR TITLE
Add the :uuid_format and :timeuuid_format options

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -620,6 +620,16 @@ defmodule Xandra do
       `value * 10^(-1 * scale)`. Defaults to `:tuple`. If you use `:decimal`,
       you'll have to add the `:decimal` dependency to your application explicitly.
 
+    * `:uuid_format` - (`:binary` or `:string`) controls the format in which UUIDs
+      are returned. When set to `:binary`, UUIDs are returned as raw binaries with
+      16 bytes in it, such as: `<<0, 182, 145, 128, 208, 225, 17, 226, 139, 139, 8,
+      0, 32, 12, 154, 102>>`. When set to `:string`, UUIDs are returned in the
+      human-readable format such as `"fe2b4360-28c6-11e2-81c1-0800200c9a66"`.
+      Defaults to `:string`.
+
+    * `:timeuuid_format` - (`:binary` or `:string`) same as the `:uuid_format`
+      option but for values of the timeuuid type. Defaults to `:string`.
+
   ## Parameters
 
   The `params` argument specifies parameters to use when executing the query; it

--- a/test/integration/datatypes_test.exs
+++ b/test/integration/datatypes_test.exs
@@ -125,15 +125,9 @@ defmodule DataTypesTest do
     assert Map.fetch!(row, "int") == -42
     assert Map.fetch!(row, "smallint") == -33
     assert Map.fetch!(row, "text") == "эликсир"
-
-    assert Map.fetch!(row, "timeuuid") ==
-             <<254, 43, 67, 96, 40, 198, 17, 226, 129, 193, 8, 0, 32, 12, 154, 102>>
-
+    assert Map.fetch!(row, "timeuuid") == "fe2b4360-28c6-11e2-81c1-0800200c9a66"
     assert Map.fetch!(row, "tinyint") == -21
-
-    assert Map.fetch!(row, "uuid") ==
-             <<0, 182, 145, 128, 208, 225, 17, 226, 139, 139, 8, 0, 32, 12, 154, 102>>
-
+    assert Map.fetch!(row, "uuid") == "00b69180-d0e1-11e2-8b8b-0800200c9a66"
     assert Map.fetch!(row, "varchar") == "тоже эликсир"
     assert Map.fetch!(row, "varint") == -6_789_065_678_192_312_391_879_827_349
   end


### PR DESCRIPTION
They work similarly to `:decimal_format` or `:timestamp_format`. By default, UUID types will be returned in human-readable form (which is a breaking change).