### PR TITLE
Make protocol version configurable at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Cover image](http://i.imgur.com/qtbgj00.jpg)
 
 Xandra is a [Cassandra][cassandra] driver built natively in Elixir and focused on speed, simplicity, and robustness.
-This driver works exclusively with the Cassandra Query Language v3 (CQL3) and the native protocol (v3, and v4 are currently supported).
+This driver works exclusively with the Cassandra Query Language v3 (CQL3) and the native protocol version 3.
 
 ## Features
 

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -230,6 +230,9 @@ defmodule Xandra do
       in `execute/4`. Can be overridden through the `:consistency` option in
       `execute/4`. Defaults to `:one`.
 
+    * `:protocol_version` - (v3) the version of the Cassandra native protocol to use.
+      Defaults to `:v3` (the only currently supported version).
+
   The rest of the options are forwarded to `DBConnection.start_link/2`. For
   example, to start a pool of five connections, you can use the `:pool_size`
   option:
@@ -281,12 +284,18 @@ defmodule Xandra do
   """
   @spec start_link(start_options) :: GenServer.on_start()
   def start_link(options \\ []) when is_list(options) do
+    protocol_module =
+      case Keyword.get(options, :protocol_version, :v3) do
+        :v3 -> Xandra.Protocol
+      end
+
     options =
       @default_start_options
       |> Keyword.merge(options)
       |> convert_nodes_options_to_address_and_port()
       |> Keyword.put(:pool, DBConnection.ConnectionPool)
       |> Keyword.put(:prepared_cache, Prepared.Cache.new())
+      |> Keyword.put(:protocol_module, protocol_module)
 
     DBConnection.start_link(Connection, options)
   end

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -230,9 +230,6 @@ defmodule Xandra do
       in `execute/4`. Can be overridden through the `:consistency` option in
       `execute/4`. Defaults to `:one`.
 
-    * `:protocol_version` - (v3) the version of the Cassandra native protocol to use.
-      Defaults to `:v3` (the only currently supported version).
-
   The rest of the options are forwarded to `DBConnection.start_link/2`. For
   example, to start a pool of five connections, you can use the `:pool_size`
   option:
@@ -284,18 +281,13 @@ defmodule Xandra do
   """
   @spec start_link(start_options) :: GenServer.on_start()
   def start_link(options \\ []) when is_list(options) do
-    protocol_module =
-      case Keyword.get(options, :protocol_version, :v3) do
-        :v3 -> Xandra.Protocol
-      end
-
     options =
       @default_start_options
       |> Keyword.merge(options)
       |> convert_nodes_options_to_address_and_port()
       |> Keyword.put(:pool, DBConnection.ConnectionPool)
       |> Keyword.put(:prepared_cache, Prepared.Cache.new())
-      |> Keyword.put(:protocol_module, protocol_module)
+      |> Keyword.put(:protocol_module, Xandra.Protocol)
 
     DBConnection.start_link(Connection, options)
   end

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -10,14 +10,15 @@ defmodule Xandra.Batch do
   alias Xandra.{Prepared, Simple}
 
   @enforce_keys [:type]
-  defstruct @enforce_keys ++ [queries: [], default_consistency: nil]
+  defstruct @enforce_keys ++ [queries: [], default_consistency: nil, protocol_module: nil]
 
   @type type :: :logged | :unlogged | :counter
 
   @opaque t(type) :: %__MODULE__{
             type: type,
             queries: [Simple.t() | Prepared.t()],
-            default_consistency: atom() | nil
+            default_consistency: atom() | nil,
+            protocol_module: module | nil
           }
 
   @type t() :: t(type)
@@ -91,7 +92,7 @@ defmodule Xandra.Batch do
   end
 
   defimpl DBConnection.Query do
-    alias Xandra.{Frame, Protocol}
+    alias Xandra.Frame
 
     def parse(batch, _options) do
       batch
@@ -101,12 +102,12 @@ defmodule Xandra.Batch do
       batch = %{batch | queries: Enum.reverse(batch.queries)}
 
       Frame.new(:batch)
-      |> Protocol.encode_request(batch, options)
-      |> Frame.encode(options[:compressor])
+      |> batch.protocol_module.encode_request(batch, options)
+      |> Frame.encode(batch.protocol_module, options[:compressor])
     end
 
     def decode(batch, %Frame{} = frame, _options) do
-      Protocol.decode_response(frame, batch)
+      batch.protocol_module.decode_response(frame, batch)
     end
 
     def describe(batch, _options) do

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -18,7 +18,7 @@ defmodule Xandra.Batch do
             type: type,
             queries: [Simple.t() | Prepared.t()],
             default_consistency: atom() | nil,
-            protocol_module: module | nil
+            protocol_module: module() | nil
           }
 
   @type t() :: t(type)

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -172,13 +172,7 @@ defmodule Xandra.Cluster do
   @spec start_link([Xandra.start_option() | {:load_balancing, atom}]) :: GenServer.on_start()
   def start_link(options) do
     options = Keyword.merge(@default_start_options, options)
-
-    protocol_module =
-      case Keyword.get(options, :protocol_version, :v3) do
-        :v3 -> Xandra.Protocol
-      end
-
-    options = Keyword.put(options, :protocol_module, protocol_module)
+    options = Keyword.put(options, :protocol_module, Xandra.Protocol)
 
     {load_balancing, options} = Keyword.pop(options, :load_balancing, @default_load_balancing)
     {nodes, options} = Keyword.pop(options, :nodes)

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -173,6 +173,13 @@ defmodule Xandra.Cluster do
   def start_link(options) do
     options = Keyword.merge(@default_start_options, options)
 
+    protocol_module =
+      case Keyword.get(options, :protocol_version, :v3) do
+        :v3 -> Xandra.Protocol
+      end
+
+    options = Keyword.put(options, :protocol_module, protocol_module)
+
     {load_balancing, options} = Keyword.pop(options, :load_balancing, @default_load_balancing)
     {nodes, options} = Keyword.pop(options, :nodes)
     {autodiscovery?, options} = Keyword.pop(options, :autodiscovery)

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -227,10 +227,7 @@ defmodule Xandra.Cluster.ControlConnection do
 
         case rest do
           <<body::size(body_length)-bytes, rest::binary>> ->
-            case Frame.decode(header, body, protocol_module) do
-              {:ok, frame} -> {frame, rest}
-              {:error, _} -> :error
-            end
+            {Frame.decode(header, body, protocol_module), rest}
 
           _ ->
             :error

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -3,7 +3,7 @@ defmodule Xandra.Cluster.ControlConnection do
 
   use Connection
 
-  alias Xandra.{Frame, Protocol, Simple, Connection.Utils}
+  alias Xandra.{Frame, Simple, Connection.Utils}
 
   require Logger
 
@@ -21,6 +21,7 @@ defmodule Xandra.Cluster.ControlConnection do
     :socket,
     :options,
     :autodiscovery,
+    :protocol_module,
     new: true,
     buffer: <<>>
   ]
@@ -50,16 +51,28 @@ defmodule Xandra.Cluster.ControlConnection do
   end
 
   def connect(_action, %__MODULE__{address: address, port: port, options: options} = state) do
+    protocol_module = Keyword.fetch!(options, :protocol_module)
+    state = %{state | protocol_module: protocol_module}
+
     case state.transport.connect(address, port, state.transport_options, @default_timeout) do
       {:ok, socket} ->
         state = %{state | socket: socket}
         transport = state.transport
 
-        with {:ok, supported_options} <- Utils.request_options(transport, socket),
-             :ok <- startup_connection(transport, socket, supported_options, options),
-             {:ok, peers_or_nil} <- maybe_discover_peers(state.autodiscovery, transport, socket),
-             :ok <- register_to_events(transport, socket),
-             :ok <- inet_mod(transport).setopts(socket, active: true) do
+        with {:ok, supported_options} <-
+               Utils.request_options(state.transport, socket, protocol_module),
+             :ok <-
+               startup_connection(
+                 state.transport,
+                 socket,
+                 supported_options,
+                 protocol_module,
+                 options
+               ),
+             {:ok, peers_or_nil} <-
+               maybe_discover_peers(state.autodiscovery, transport, socket, protocol_module),
+             :ok <- register_to_events(state.transport, socket, protocol_module),
+             :ok <- inet_mod(state.transport).setopts(socket, active: true) do
           {:ok, state} = report_active(state)
 
           if not is_nil(peers_or_nil) do
@@ -114,36 +127,36 @@ defmodule Xandra.Cluster.ControlConnection do
     :ok = Xandra.Cluster.discovered_peers(state.cluster, peers)
   end
 
-  defp startup_connection(transport, socket, supported_options, options) do
+  defp startup_connection(transport, socket, supported_options, protocol_module, options) do
     %{"CQL_VERSION" => [cql_version | _]} = supported_options
     requested_options = %{"CQL_VERSION" => cql_version}
-    Utils.startup_connection(transport, socket, requested_options, nil, options)
+    Utils.startup_connection(transport, socket, requested_options, protocol_module, nil, options)
   end
 
-  defp register_to_events(transport, socket) do
+  defp register_to_events(transport, socket, protocol_module) do
     payload =
       Frame.new(:register)
-      |> Protocol.encode_request(["STATUS_CHANGE", "TOPOLOGY_CHANGE"])
-      |> Frame.encode()
+      |> protocol_module.encode_request(["STATUS_CHANGE", "TOPOLOGY_CHANGE"])
+      |> Frame.encode(protocol_module)
 
     with :ok <- transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <- Utils.recv_frame(transport, socket) do
-      :ok = Protocol.decode_response(frame)
+         {:ok, %Frame{} = frame} <- Utils.recv_frame(transport, socket, protocol_module) do
+      :ok = protocol_module.decode_response(frame)
     else
       {:error, reason} ->
         {:error, reason}
     end
   end
 
-  defp maybe_discover_peers(_autodiscovery? = false, _transport, _socket) do
+  defp maybe_discover_peers(_autodiscovery? = false, _transport, _socket, _protocol_module) do
     {:ok, _peers = nil}
   end
 
-  defp maybe_discover_peers(_autodiscovery? = true, transport, socket) do
+  defp maybe_discover_peers(_autodiscovery? = true, transport, socket, protocol_module) do
     # Discover the peers in the same data center as the node we're connected to.
-    with {:ok, local_info} <- fetch_node_local_info(transport, socket),
+    with {:ok, local_info} <- fetch_node_local_info(transport, socket, protocol_module),
          local_data_center = Map.fetch!(local_info, "data_center"),
-         {:ok, peers} <- discover_peers(transport, socket) do
+         {:ok, peers} <- discover_peers(transport, socket, protocol_module) do
       peers =
         for %{"data_center" => data_center, "rpc_address" => address} <- peers,
             data_center == local_data_center,
@@ -153,7 +166,7 @@ defmodule Xandra.Cluster.ControlConnection do
     end
   end
 
-  defp fetch_node_local_info(transport, socket) do
+  defp fetch_node_local_info(transport, socket, protocol_module) do
     query = %Simple{
       statement: "SELECT data_center FROM system.local",
       values: [],
@@ -162,18 +175,18 @@ defmodule Xandra.Cluster.ControlConnection do
 
     payload =
       Frame.new(:query)
-      |> Protocol.encode_request(query)
-      |> Frame.encode()
+      |> protocol_module.encode_request(query)
+      |> Frame.encode(protocol_module)
 
     with :ok <- transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <- Utils.recv_frame(transport, socket) do
-      %Xandra.Page{} = page = Protocol.decode_response(frame, query)
+         {:ok, %Frame{} = frame} <- Utils.recv_frame(transport, socket, protocol_module) do
+      %Xandra.Page{} = page = protocol_module.decode_response(frame, query)
       [local_info] = Enum.to_list(page)
       {:ok, local_info}
     end
   end
 
-  defp discover_peers(transport, socket) do
+  defp discover_peers(transport, socket, protocol_module) do
     query = %Simple{
       statement: "SELECT rpc_address, data_center FROM system.peers",
       values: [],
@@ -182,20 +195,20 @@ defmodule Xandra.Cluster.ControlConnection do
 
     payload =
       Frame.new(:query)
-      |> Protocol.encode_request(query)
-      |> Frame.encode()
+      |> protocol_module.encode_request(query)
+      |> Frame.encode(protocol_module)
 
     with :ok <- transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <- Utils.recv_frame(transport, socket) do
-      %Xandra.Page{} = page = Protocol.decode_response(frame, query)
+         {:ok, %Frame{} = frame} <- Utils.recv_frame(transport, socket, protocol_module) do
+      %Xandra.Page{} = page = protocol_module.decode_response(frame, query)
       {:ok, Enum.to_list(page)}
     end
   end
 
   defp report_event(%{cluster: cluster, buffer: buffer} = state) do
-    case decode_frame(buffer) do
+    case decode_frame(buffer, state.protocol_module) do
       {frame, rest} ->
-        change_event = Protocol.decode_response(frame)
+        change_event = state.protocol_module.decode_response(frame)
         Logger.debug("Received event: #{inspect(change_event)}")
         Xandra.Cluster.update(cluster, change_event)
         report_event(%{state | buffer: rest})
@@ -205,7 +218,7 @@ defmodule Xandra.Cluster.ControlConnection do
     end
   end
 
-  defp decode_frame(buffer) do
+  defp decode_frame(buffer, protocol_module) do
     header_length = Frame.header_length()
 
     case buffer do
@@ -214,7 +227,10 @@ defmodule Xandra.Cluster.ControlConnection do
 
         case rest do
           <<body::size(body_length)-bytes, rest::binary>> ->
-            {Frame.decode(header, body), rest}
+            case Frame.decode(header, body, protocol_module) do
+              {:ok, frame} -> {frame, rest}
+              {:error, _} -> :error
+            end
 
           _ ->
             :error

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -3,7 +3,7 @@ defmodule Xandra.Connection do
 
   use DBConnection
 
-  alias Xandra.{Batch, ConnectionError, Prepared, Frame, Protocol, Simple}
+  alias Xandra.{Batch, ConnectionError, Prepared, Frame, Simple}
   alias __MODULE__.Utils
 
   @default_timeout 5_000
@@ -16,7 +16,8 @@ defmodule Xandra.Connection do
     :prepared_cache,
     :compressor,
     :default_consistency,
-    :atom_keys?
+    :atom_keys?,
+    :protocol_module
   ]
 
   @impl true
@@ -27,6 +28,7 @@ defmodule Xandra.Connection do
     compressor = Keyword.get(options, :compressor)
     default_consistency = Keyword.fetch!(options, :default_consistency)
     atom_keys? = Keyword.get(options, :atom_keys, false)
+    protocol_module = Keyword.fetch!(options, :protocol_module)
     transport = if(options[:encryption], do: :ssl, else: :gen_tcp)
 
     transport_options =
@@ -43,11 +45,21 @@ defmodule Xandra.Connection do
           prepared_cache: prepared_cache,
           compressor: compressor,
           default_consistency: default_consistency,
-          atom_keys?: atom_keys?
+          atom_keys?: atom_keys?,
+          protocol_module: protocol_module
         }
 
-        with {:ok, supported_options} <- Utils.request_options(transport, socket),
-             :ok <- startup_connection(transport, socket, supported_options, compressor, options) do
+        with {:ok, supported_options} <-
+               Utils.request_options(transport, socket, protocol_module),
+             :ok <-
+               startup_connection(
+                 transport,
+                 socket,
+                 supported_options,
+                 protocol_module,
+                 compressor,
+                 options
+               ) do
           {:ok, state}
         else
           {:error, reason} = error ->
@@ -109,6 +121,7 @@ defmodule Xandra.Connection do
   @impl true
   def handle_prepare(%Prepared{} = prepared, options, %__MODULE__{socket: socket} = state) do
     prepared = %{prepared | default_consistency: state.default_consistency}
+    prepared = %{prepared | protocol_module: state.protocol_module}
 
     force? = Keyword.get(options, :force, false)
     compressor = assert_valid_compressor(state.compressor, options[:compressor])
@@ -121,13 +134,14 @@ defmodule Xandra.Connection do
       :error ->
         payload =
           Frame.new(:prepare)
-          |> Protocol.encode_request(prepared)
-          |> Frame.encode(compressor)
+          |> state.protocol_module.encode_request(prepared)
+          |> Frame.encode(state.protocol_module, compressor)
 
         with :ok <- transport.send(socket, payload),
-             {:ok, %Frame{} = frame} <- Utils.recv_frame(transport, socket, state.compressor),
+             {:ok, %Frame{} = frame} <-
+               Utils.recv_frame(transport, socket, state.protocol_module, state.compressor),
              frame = %{frame | atom_keys?: state.atom_keys?},
-             %Prepared{} = prepared <- Protocol.decode_response(frame, prepared) do
+             %Prepared{} = prepared <- state.protocol_module.decode_response(frame, prepared) do
           Prepared.Cache.insert(state.prepared_cache, prepared)
           {:ok, prepared, state}
         else
@@ -142,12 +156,12 @@ defmodule Xandra.Connection do
 
   def handle_prepare(%Simple{} = simple, _options, state) do
     simple = %{simple | default_consistency: state.default_consistency}
-    {:ok, simple, state}
+    {:ok, %{simple | protocol_module: state.protocol_module}, state}
   end
 
   def handle_prepare(%Batch{} = batch, _options, state) do
     batch = %{batch | default_consistency: state.default_consistency}
-    {:ok, batch, state}
+    {:ok, %{batch | protocol_module: state.protocol_module}, state}
   end
 
   @impl true
@@ -156,7 +170,8 @@ defmodule Xandra.Connection do
     assert_valid_compressor(compressor, options[:compressor])
 
     with :ok <- state.transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <- Utils.recv_frame(state.transport, socket, compressor) do
+         {:ok, %Frame{} = frame} <-
+           Utils.recv_frame(state.transport, socket, state.protocol_module, compressor) do
       {:ok, query, %{frame | atom_keys?: atom_keys?}, state}
     else
       {:error, reason} ->
@@ -176,7 +191,7 @@ defmodule Xandra.Connection do
 
   @impl true
   def ping(%__MODULE__{socket: socket, compressor: compressor} = state) do
-    case Utils.request_options(state.transport, socket, compressor) do
+    case Utils.request_options(state.transport, socket, state.protocol_module, compressor) do
       {:ok, _options} ->
         {:ok, state}
 
@@ -194,7 +209,14 @@ defmodule Xandra.Connection do
     Prepared.Cache.lookup(state.prepared_cache, prepared)
   end
 
-  defp startup_connection(transport, socket, supported_options, compressor, options) do
+  defp startup_connection(
+         transport,
+         socket,
+         supported_options,
+         protocol_module,
+         compressor,
+         options
+       ) do
     %{
       "CQL_VERSION" => [cql_version | _],
       "COMPRESSION" => supported_compression_algorithms
@@ -207,7 +229,15 @@ defmodule Xandra.Connection do
 
       if compression_algorithm in supported_compression_algorithms do
         requested_options = Map.put(requested_options, "COMPRESSION", compression_algorithm)
-        Utils.startup_connection(transport, socket, requested_options, compressor, options)
+
+        Utils.startup_connection(
+          transport,
+          socket,
+          requested_options,
+          protocol_module,
+          compressor,
+          options
+        )
       else
         {:error,
          ConnectionError.new(
@@ -216,7 +246,14 @@ defmodule Xandra.Connection do
          )}
       end
     else
-      Utils.startup_connection(transport, socket, requested_options, compressor, options)
+      Utils.startup_connection(
+        transport,
+        socket,
+        requested_options,
+        protocol_module,
+        compressor,
+        options
+      )
     end
   end
 

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -120,8 +120,11 @@ defmodule Xandra.Connection do
 
   @impl true
   def handle_prepare(%Prepared{} = prepared, options, %__MODULE__{socket: socket} = state) do
-    prepared = %{prepared | default_consistency: state.default_consistency}
-    prepared = %{prepared | protocol_module: state.protocol_module}
+    prepared = %{
+      prepared
+      | default_consistency: state.default_consistency,
+        protocol_module: state.protocol_module
+    }
 
     force? = Keyword.get(options, :force, false)
     compressor = assert_valid_compressor(state.compressor, options[:compressor])
@@ -155,13 +158,23 @@ defmodule Xandra.Connection do
   end
 
   def handle_prepare(%Simple{} = simple, _options, state) do
-    simple = %{simple | default_consistency: state.default_consistency}
-    {:ok, %{simple | protocol_module: state.protocol_module}, state}
+    simple = %{
+      simple
+      | default_consistency: state.default_consistency,
+        protocol_module: state.protocol_module
+    }
+
+    {:ok, simple, state}
   end
 
   def handle_prepare(%Batch{} = batch, _options, state) do
-    batch = %{batch | default_consistency: state.default_consistency}
-    {:ok, %{batch | protocol_module: state.protocol_module}, state}
+    batch = %{
+      batch
+      | default_consistency: state.default_consistency,
+        protocol_module: state.protocol_module
+    }
+
+    {:ok, batch, state}
   end
 
   @impl true

--- a/lib/xandra/connection/utils.ex
+++ b/lib/xandra/connection/utils.ex
@@ -1,64 +1,92 @@
 defmodule Xandra.Connection.Utils do
   @moduledoc false
 
-  alias Xandra.{ConnectionError, Frame, Protocol}
+  alias Xandra.{ConnectionError, Error, Frame}
 
-  @spec recv_frame(:gen_tcp | :ssl, term, nil | module) ::
+  @spec recv_frame(:gen_tcp | :ssl, term, module, nil | module) ::
           {:ok, Frame.t()} | {:error, :closed | :inet.posix()}
-  def recv_frame(transport, socket, compressor \\ nil) when is_atom(compressor) do
+  def recv_frame(transport, socket, protocol_module, compressor \\ nil)
+      when is_atom(compressor) do
     length = Frame.header_length()
 
     with {:ok, header} <- transport.recv(socket, length) do
       case Frame.body_length(header) do
         0 ->
-          {:ok, Frame.decode(header)}
+          Frame.decode(header, protocol_module)
 
         body_length ->
           with {:ok, body} <- transport.recv(socket, body_length),
-               do: {:ok, Frame.decode(header, body, compressor)}
+               do: Frame.decode(header, body, protocol_module, compressor)
       end
     end
   end
 
-  @spec request_options(:gen_tcp | :ssl, term, nil | module) ::
+  @spec request_options(:gen_tcp | :ssl, term, module, nil | module) ::
           {:ok, term} | {:error, ConnectionError.t()}
-  def request_options(transport, socket, compressor \\ nil) do
+  def request_options(transport, socket, protocol_module, compressor \\ nil) do
     payload =
       Frame.new(:options)
-      |> Protocol.encode_request(nil)
-      |> Frame.encode()
+      |> protocol_module.encode_request(nil)
+      |> Frame.encode(protocol_module)
 
     with :ok <- transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <- recv_frame(transport, socket, compressor) do
-      {:ok, Protocol.decode_response(frame)}
+         {:ok, %Frame{} = frame} <- recv_frame(transport, socket, protocol_module, compressor),
+         %{"CQL_VERSION" => _} = response <- protocol_module.decode_response(frame) do
+      {:ok, response}
     else
       {:error, reason} ->
         {:error, ConnectionError.new("request options", reason)}
+
+      %Error{} = error ->
+        {:error, ConnectionError.new("request options", error)}
     end
   end
 
-  @spec startup_connection(:gen_tcp | :ssl, term, map, nil | module) ::
+  @spec startup_connection(:gen_tcp | :ssl, term, map, module, nil | module) ::
           :ok | {:error, ConnectionError.t()}
-  def startup_connection(transport, socket, requested_options, compressor \\ nil, options \\ [])
+  def startup_connection(
+        transport,
+        socket,
+        requested_options,
+        protocol_module,
+        compressor \\ nil,
+        options \\ []
+      )
       when is_map(requested_options) and is_atom(compressor) do
     # We have to encode the STARTUP frame without compression as in this frame
     # we tell the server which compression algorithm we want to use.
     payload =
       Frame.new(:startup)
-      |> Protocol.encode_request(requested_options)
-      |> Frame.encode()
+      |> protocol_module.encode_request(requested_options)
+      |> Frame.encode(protocol_module)
 
     # However, we need to pass the compressor module around when we
     # receive the response to this frame because if we said we want to use
     # compression, this response is already compressed.
     with :ok <- transport.send(socket, payload),
-         {:ok, frame} <- recv_frame(transport, socket, compressor) do
+         {:ok, frame} <- recv_frame(transport, socket, protocol_module, compressor) do
       case frame do
         %Frame{body: <<>>} ->
           :ok
 
         %Frame{kind: :authenticate} ->
-          authenticate_connection(transport, socket, requested_options, compressor, options)
+          authenticate_connection(
+            transport,
+            socket,
+            requested_options,
+            protocol_module,
+            compressor,
+            options
+          )
+
+        %Frame{kind: :error} ->
+          # errors like
+          # %Xandra.Error{
+          #   message: "Invalid message version. Got 4/v4 but previous messages on this connection had version 3/v3",
+          #   reason: :protocol_violation
+          # }
+          error = %Error{} = protocol_module.decode_response(frame)
+          raise error
 
         _ ->
           raise "protocol violation, got unexpected frame: #{inspect(frame)}"
@@ -69,17 +97,24 @@ defmodule Xandra.Connection.Utils do
     end
   end
 
-  defp authenticate_connection(transport, socket, requested_options, compressor, options) do
+  defp authenticate_connection(
+         transport,
+         socket,
+         requested_options,
+         protocol_module,
+         compressor,
+         options
+       ) do
     payload =
       Frame.new(:auth_response)
-      |> Protocol.encode_request(requested_options, options)
-      |> Frame.encode()
+      |> protocol_module.encode_request(requested_options, options)
+      |> Frame.encode(protocol_module)
 
     with :ok <- transport.send(socket, payload),
-         {:ok, frame} <- recv_frame(transport, socket, compressor) do
+         {:ok, frame} <- recv_frame(transport, socket, protocol_module, compressor) do
       case frame do
         %Frame{kind: :auth_success} -> :ok
-        %Frame{kind: :error} -> {:error, Protocol.decode_response(frame)}
+        %Frame{kind: :error} -> {:error, protocol_module.decode_response(frame)}
         _ -> raise "protocol violation, got unexpected frame: #{inspect(frame)}"
       end
     else

--- a/lib/xandra/frame.ex
+++ b/lib/xandra/frame.ex
@@ -10,7 +10,7 @@ defmodule Xandra.Frame do
   @type t(kind) :: %__MODULE__{kind: kind}
   @type t :: t(kind)
 
-  @request_version 0x03
+  @request_version %{v1: 0x01, v2: 0x02, v3: 0x03, v4: 0x04, v5: 0x05}
 
   @request_opcodes %{
     :startup => 0x01,
@@ -23,7 +23,8 @@ defmodule Xandra.Frame do
     :auth_response => 0x0F
   }
 
-  @response_version 0x83
+  @response_version %{v1: 0x81, v2: 0x82, v3: 0x83, v4: 0x84, v5: 0x85}
+  @protocol_version %{0x81 => :v1, 0x82 => :v2, 0x83 => :v3, 0x84 => :v4, 0x85 => :v5}
 
   @response_opcodes %{
     0x00 => :error,
@@ -49,13 +50,13 @@ defmodule Xandra.Frame do
   end
 
   @spec encode(t(kind), module, nil | module) :: iodata
-  def encode(%__MODULE__{} = frame, _protocol_module, compressor \\ nil)
+  def encode(%__MODULE__{} = frame, protocol_module, compressor \\ nil)
       when is_atom(compressor) do
     %{tracing: tracing?, kind: kind, stream_id: stream_id, body: body} = frame
     body = maybe_compress_body(compressor, body)
 
     [
-      @request_version,
+      @request_version[protocol_module.protocol_version],
       encode_flags(compressor, tracing?),
       <<stream_id::16>>,
       Map.fetch!(@request_opcodes, kind),
@@ -68,20 +69,21 @@ defmodule Xandra.Frame do
   def decode(header, body \\ <<>>, protocol_module, compressor \\ nil)
       when is_binary(body) and is_atom(compressor) do
     <<response_version, flags, _stream_id::16, opcode, _::32>> = header
+    expected_response_version = @response_version[protocol_module.protocol_version]
 
-    if assert_correct_response_version(response_version, protocol_module) do
+    if assert_correct_response_version(response_version, expected_response_version) do
       kind = Map.fetch!(@response_opcodes, opcode)
       body = maybe_decompress_body(flag_set?(flags, _compression = 0x01), compressor, body)
       {:ok, %__MODULE__{kind: kind, body: body}}
     else
       {:error,
-       "you requested protocol v#{protocol_module} " <>
-         "but server answered with protocol v#{inspect(response_version, base: :hex)}"}
+       "you requested protocol #{protocol_module.protocol_version} " <>
+         "but server answered with #{@protocol_version[response_version]}"}
     end
   end
 
-  def assert_correct_response_version(response_version, _protocol_module) do
-    @response_version == response_version
+  def assert_correct_response_version(actual, expected) do
+    actual == expected
   end
 
   defp encode_flags(_compressor = nil, _tracing? = false), do: 0x00

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -41,8 +41,6 @@ defmodule Xandra.Protocol do
     end
   end
 
-  def protocol_version, do: :v3
-
   @spec encode_request(Frame.t(kind), term, keyword) :: Frame.t(kind) when kind: var
   def encode_request(frame, params, options \\ [])
 

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -41,6 +41,8 @@ defmodule Xandra.Protocol do
     end
   end
 
+  def protocol_version, do: :v3
+
   @spec encode_request(Frame.t(kind), term, keyword) :: Frame.t(kind) when kind: var
   def encode_request(frame, params, options \\ [])
 

--- a/lib/xandra/simple.ex
+++ b/lib/xandra/simple.ex
@@ -7,7 +7,7 @@ defmodule Xandra.Simple do
             statement: Xandra.statement(),
             values: Xandra.values() | nil,
             default_consistency: atom() | nil,
-            protocol_module: module | nil
+            protocol_module: module() | nil
           }
 
   defimpl DBConnection.Query do


### PR DESCRIPTION
Preparation for #144, make the protocol configurable at runtime, add it to the connection state and  store it in the query structs to have it available when encoding and decoding queries.