### PR TITLE
Fix :inet type to use 8-element tuples like :inet.ip6_address/0

### DIFF
--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -145,9 +145,9 @@ defmodule Xandra.Cluster.ControlConnection do
          local_data_center = Map.fetch!(local_info, "data_center"),
          {:ok, peers} <- discover_peers(transport, socket) do
       peers =
-        for %{"data_center" => data_center, "peer" => peer} <- peers,
+        for %{"data_center" => data_center, "rpc_address" => address} <- peers,
             data_center == local_data_center,
-            do: peer
+            do: address
 
       {:ok, peers}
     end

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -372,14 +372,11 @@ defmodule Xandra.Protocol do
     <<value::32-float>>
   end
 
-  defp encode_value(:inet, {n1, n2, n3, n4})
-       when is_integer(n1) and is_integer(n2) and is_integer(n3) and is_integer(n4) do
+  defp encode_value(:inet, {n1, n2, n3, n4}) do
     <<n1, n2, n3, n4>>
   end
 
-  defp encode_value(:inet, {n1, n2, n3, n4, n5, n6, n7, n8})
-       when is_integer(n1) and is_integer(n2) and is_integer(n3) and is_integer(n4) and
-              is_integer(n5) and is_integer(n6) and is_integer(n7) and is_integer(n8) do
+  defp encode_value(:inet, {n1, n2, n3, n4, n5, n6, n7, n8}) do
     <<n1::16, n2::16, n3::16, n4::16, n5::16, n6::16, n7::16, n8::16>>
   end
 

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -372,7 +372,8 @@ defmodule Xandra.Protocol do
     <<value::32-float>>
   end
 
-  defp encode_value(:inet, {n1, n2, n3, n4}) do
+  defp encode_value(:inet, {n1, n2, n3, n4})
+       when is_integer(n1) and is_integer(n2) and is_integer(n3) and is_integer(n4) do
     <<n1, n2, n3, n4>>
   end
 
@@ -773,8 +774,8 @@ defmodule Xandra.Protocol do
   end
 
   defp decode_value(<<data::16-bytes>>, :inet) do
-    <<n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14, n15, n16>> = data
-    {n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14, n15, n16}
+    <<n1::16, n2::16, n3::16, n4::16, n5::16, n6::16, n7::16, n8::16>> = data
+    {n1, n2, n3, n4, n5, n6, n7, n8}
   end
 
   defp decode_value(<<value::16-bytes>>, {uuid_type, [format]})

--- a/lib/xandra/protocol.ex
+++ b/lib/xandra/protocol.ex
@@ -377,11 +377,10 @@ defmodule Xandra.Protocol do
     <<n1, n2, n3, n4>>
   end
 
-  defp encode_value(:inet, {n1, n2, n3, n4, n5, n6, n7, n8}) do
-    <<
-      (<<n1::4-bytes, n2::4-bytes, n3::4-bytes, n4::4-bytes>>),
-      (<<n5::4-bytes, n6::4-bytes, n7::4-bytes, n8::4-bytes>>)
-    >>
+  defp encode_value(:inet, {n1, n2, n3, n4, n5, n6, n7, n8})
+       when is_integer(n1) and is_integer(n2) and is_integer(n3) and is_integer(n4) and
+              is_integer(n5) and is_integer(n6) and is_integer(n7) and is_integer(n8) do
+    <<n1::16, n2::16, n3::16, n4::16, n5::16, n6::16, n7::16, n8::16>>
   end
 
   defp encode_value(:int, value) when is_integer(value) do

--- a/test/integration/datatypes_test.exs
+++ b/test/integration/datatypes_test.exs
@@ -546,8 +546,7 @@ defmodule DataTypesTest do
     """
 
     addr = {127, 0, 0, 1}
-    # addrv6 = {64935, 43320, 23550, 24486, 0, 0, 0, 49}
-    addrv6 = {"aaaa", "aaaa", "aaaa", "aaaa", "aaaa", "aaaa", "aaaa", "aaaa"}
+    addrv6 = {64935, 43320, 23550, 24486, 0, 0, 0, 49}
 
     Xandra.execute!(conn, statement)
 

--- a/test/integration/datatypes_test.exs
+++ b/test/integration/datatypes_test.exs
@@ -536,4 +536,37 @@ defmodule DataTypesTest do
     assert Map.fetch!(row, "id") == 1
     assert Map.fetch!(row, "total") == 4
   end
+
+  test "inet type", %{conn: conn} do
+    statement = """
+    CREATE TABLE inets
+    (id int PRIMARY KEY,
+     addr inet,
+     addrv6 inet)
+    """
+
+    addr = {127, 0, 0, 1}
+    # addrv6 = {64935, 43320, 23550, 24486, 0, 0, 0, 49}
+    addrv6 = {"aaaa", "aaaa", "aaaa", "aaaa", "aaaa", "aaaa", "aaaa", "aaaa"}
+
+    Xandra.execute!(conn, statement)
+
+    statement = """
+    INSERT INTO inets (id, addr, addrv6) VALUES (?, ?, ?)
+    """
+
+    values = [
+      {"int", 1},
+      {"inet", addr},
+      {"inet", addrv6}
+    ]
+
+    Xandra.execute!(conn, statement, values)
+
+    page = Xandra.execute!(conn, "SELECT * FROM inets WHERE id = 1")
+    assert [row] = Enum.to_list(page)
+    assert Map.fetch!(row, "id") == 1
+    assert Map.fetch!(row, "addr") == addr
+    assert Map.fetch!(row, "addrv6") == addrv6
+  end
 end


### PR DESCRIPTION
We were:

* decoding `:inet` IPv6 addresses as 16-element tuples with 16 single bytes
* encoding `:inet` IPv6 addresses from 8-element tuples containing 8 strings (the human-readable representation of IPv6 addresses)

I moved both what we encode and what we return when decoding to `:inet.ip6_address/0`, that is, 8-element tuples containing 8 integers. This means that now users can do stuff like fetch an inet from C* and use it directly in `:gen_tcp.connect/4` for example instead of having to do weird conversion.