### PR TITLE
Change opaque to type for dialyzer

### DIFF
--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -14,12 +14,12 @@ defmodule Xandra.Batch do
 
   @type type :: :logged | :unlogged | :counter
 
-  @opaque t(type) :: %__MODULE__{
-            type: type,
-            queries: [Simple.t() | Prepared.t()],
-            default_consistency: atom() | nil,
-            protocol_module: module() | nil
-          }
+  @type t(type) :: %__MODULE__{
+          type: type,
+          queries: [Simple.t() | Prepared.t()],
+          default_consistency: atom() | nil,
+          protocol_module: module() | nil
+        }
 
   @type t() :: t(type)
 

--- a/lib/xandra/page.ex
+++ b/lib/xandra/page.ex
@@ -34,11 +34,11 @@ defmodule Xandra.Page do
 
   @type paging_state :: binary | nil
 
-  @opaque t :: %__MODULE__{
-            content: list,
-            columns: nonempty_list,
-            paging_state: paging_state
-          }
+  @type t :: %__MODULE__{
+          content: list,
+          columns: nonempty_list,
+          paging_state: paging_state
+        }
 
   @doc false
   @spec more_pages_available?(t) :: boolean

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -13,15 +13,15 @@ defmodule Xandra.Prepared do
     :protocol_module
   ]
 
-  @opaque t :: %__MODULE__{
-            statement: Xandra.statement(),
-            values: Xandra.values() | nil,
-            id: binary | nil,
-            bound_columns: list | nil,
-            result_columns: list | nil,
-            default_consistency: atom | nil,
-            protocol_module: module | nil
-          }
+  @type t :: %__MODULE__{
+          statement: Xandra.statement(),
+          values: Xandra.values() | nil,
+          id: binary | nil,
+          bound_columns: list | nil,
+          result_columns: list | nil,
+          default_consistency: atom | nil,
+          protocol_module: module | nil
+        }
 
   @doc false
   def rewrite_named_params_to_positional(%__MODULE__{} = prepared, params)

--- a/lib/xandra/simple.ex
+++ b/lib/xandra/simple.ex
@@ -3,12 +3,12 @@ defmodule Xandra.Simple do
 
   defstruct [:statement, :values, :default_consistency, :protocol_module]
 
-  @opaque t :: %__MODULE__{
-            statement: Xandra.statement(),
-            values: Xandra.values() | nil,
-            default_consistency: atom() | nil,
-            protocol_module: module() | nil
-          }
+  @type t :: %__MODULE__{
+          statement: Xandra.statement(),
+          values: Xandra.values() | nil,
+          default_consistency: atom() | nil,
+          protocol_module: module() | nil
+        }
 
   defimpl DBConnection.Query do
     alias Xandra.Frame


### PR DESCRIPTION
Dialyzer does not support correctly `@opaque`.

When doing something like this
```elixir
  {:ok, query} = Xandra.prepare(conn, query)
  Xandra.execute(conn, query, params)
```

Dialyzer raise the warning :

> 
> The call
> ```erlang
> 'Elixir.Xandra':execute(
>   _conn@1::atom() | pid() | {atom(),_} | {'via',atom(),_} | #{'__struct__':='Elixir.DBConnection', 'conn_mode':=_, 'conn_ref':=reference(), 'pool_ref':=_},
>   _query@1::'Elixir.Xandra.Prepared':t(),
>   _params@1::any()
> )
> ```
> does not have a term of type
> ```erlang
> binary() | #{'__struct__':='Elixir.Xandra.Batch' | 'Elixir.Xandra.Prepared', _=>_}
> ```
> (with opaque subterms) as 2nd argument

If I understand correctly dialyzer cannot check the field `__struct__` because the type is `opaque`.
By changing the `@opaque` to `@type`, it fixes the warning.
I don't know what was the choice of using `opaque` in `Batch`, `Page`, `Prepared` and `Simple` modules and if it's fine for you to remove them.