### PR TITLE
Tracing support

### DIFF
--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -105,7 +105,7 @@ defmodule Xandra.Batch do
     def encode(batch, nil, options) do
       batch = %{batch | queries: Enum.reverse(batch.queries)}
 
-      Frame.new(:batch, Keyword.take(options, [:compressor]))
+      Frame.new(:batch, Keyword.take(options, [:compressor, :tracing]))
       |> batch.protocol_module.encode_request(batch, options)
       |> Frame.encode(batch.protocol_module)
     end

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -135,8 +135,11 @@ defmodule Xandra.Connection do
         {:ok, prepared, state}
 
       :error ->
+        frame_options =
+          options |> Keyword.take([:tracing]) |> Keyword.put(:compressor, compressor)
+
         payload =
-          Frame.new(:prepare, compressor: compressor)
+          Frame.new(:prepare, frame_options)
           |> state.protocol_module.encode_request(prepared)
           |> Frame.encode(state.protocol_module)
 

--- a/lib/xandra/frame.ex
+++ b/lib/xandra/frame.ex
@@ -68,7 +68,11 @@ defmodule Xandra.Frame do
 
   @spec new(kind, keyword) :: t(kind) when kind: var
   def new(kind, options \\ []) do
-    %__MODULE__{kind: kind, compressor: options[:compressor]}
+    %__MODULE__{
+      kind: kind,
+      compressor: Keyword.get(options, :compressor),
+      tracing: Keyword.get(options, :tracing, false)
+    }
   end
 
   @spec header_length() :: 9
@@ -111,12 +115,19 @@ defmodule Xandra.Frame do
     assert_response_version_matches_request(response_version, protocol_module)
 
     compression? = flag_set?(flags, _compression = 0x01)
+    tracing? = flag_set?(flags, _tracing = 0x02)
     warning? = flag_set?(flags, _warning? = 0x08)
 
     kind = Map.fetch!(@response_opcodes, opcode)
     body = maybe_decompress_body(compression?, compressor, body)
 
-    %__MODULE__{kind: kind, body: body, warning: warning?, compressor: compressor}
+    %__MODULE__{
+      kind: kind,
+      body: body,
+      tracing: tracing?,
+      warning: warning?,
+      compressor: compressor
+    }
   end
 
   defp assert_response_version_matches_request(response_version, protocol_module) do

--- a/lib/xandra/page.ex
+++ b/lib/xandra/page.ex
@@ -30,14 +30,15 @@ defmodule Xandra.Page do
 
   """
 
-  defstruct [:content, :columns, :paging_state]
+  defstruct [:content, :columns, :paging_state, :tracing_id]
 
   @type paging_state :: binary | nil
 
   @type t :: %__MODULE__{
           content: list,
           columns: nonempty_list,
-          paging_state: paging_state
+          paging_state: paging_state,
+          tracing_id: binary | nil
         }
 
   defimpl Enumerable do
@@ -81,6 +82,7 @@ defmodule Xandra.Page do
     def inspect(page, options) do
       properties = [
         rows: Enum.to_list(page),
+        tracing_id: page.tracing_id,
         more_pages?: page.paging_state != nil
       ]
 

--- a/lib/xandra/page.ex
+++ b/lib/xandra/page.ex
@@ -15,10 +15,13 @@ defmodule Xandra.Page do
 
   The following fields are public and can be accessed or relied on:
 
-    * `paging_state` - the current paging state. Its value can be used to check
+    * `:paging_state` - the current paging state. Its value can be used to check
       whether more pages are available to fetch after the given page.
       This is useful when implementing manual paging.
       See also the documentation for `Xandra.execute/4`.
+
+    * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
+      or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
   ## Examples
 

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -14,7 +14,8 @@ defmodule Xandra.Prepared do
     :bound_columns,
     :result_columns,
     :default_consistency,
-    :protocol_module
+    :protocol_module,
+    :tracing_id
   ]
 
   @type t :: %__MODULE__{
@@ -24,7 +25,8 @@ defmodule Xandra.Prepared do
           bound_columns: list | nil,
           result_columns: list | nil,
           default_consistency: atom | nil,
-          protocol_module: module | nil
+          protocol_module: module | nil,
+          tracing_id: binary | nil
         }
 
   @doc false
@@ -73,7 +75,12 @@ defmodule Xandra.Prepared do
     import Inspect.Algebra
 
     def inspect(prepared, options) do
-      concat(["#Xandra.Prepared<", to_doc(prepared.statement, options), ">"])
+      properties = [
+        statement: prepared.statement,
+        tracing_id: prepared.tracing_id
+      ]
+
+      concat(["#Xandra.Prepared<", to_doc(properties, options), ">"])
     end
   end
 end

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -57,7 +57,7 @@ defmodule Xandra.Prepared do
     end
 
     def encode(prepared, values, options) when is_list(values) do
-      Frame.new(:execute, Keyword.take(options, [:compressor]))
+      Frame.new(:execute, Keyword.take(options, [:compressor, :tracing]))
       |> prepared.protocol_module.encode_request(%{prepared | values: values}, options)
       |> Frame.encode(prepared.protocol_module)
     end

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -2,9 +2,13 @@ defmodule Xandra.Prepared do
   @moduledoc """
   A data structure used to internally represent prepared queries.
 
-  Note that the `t:t/0` type is public because it would cause Dialyzer
-  warnings if it were opaque. However, the `Xandra.Prepared` struct is
-  private API and is not meant to be used directly.
+  These are the publicly accessible fields of this struct:
+
+    * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
+      or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
+
+  All other fields are documented in `t:t/0` to avoid Dialyzer warnings,
+  but are not meant to be used by users.
   """
 
   defstruct [

--- a/lib/xandra/protocol/v3.ex
+++ b/lib/xandra/protocol/v3.ex
@@ -26,6 +26,12 @@ defmodule Xandra.Protocol.V3 do
     end
   end
 
+  defmacrop decode_uuid({:<-, _, [value, buffer]}) do
+    quote do
+      <<unquote(value)::16-bytes, unquote(buffer)::bits>> = unquote(buffer)
+    end
+  end
+
   defmacrop decode_value({:<-, _, [value, buffer]}, type, do: block) do
     quote do
       <<size::32-signed, unquote(buffer)::bits>> = unquote(buffer)
@@ -564,12 +570,13 @@ defmodule Xandra.Protocol.V3 do
   end
 
   def decode_response(
-        %Frame{kind: :result, body: body, atom_keys?: atom_keys?},
+        %Frame{kind: :result, body: body, tracing: tracing?, atom_keys?: atom_keys?},
         %kind{} = query,
         options
       )
       when kind in [Simple, Prepared, Batch] do
-    decode_result_response(body, query, Keyword.put(options, :atom_keys?, atom_keys?))
+    {body, tracing_id} = decode_tracing_id(body, tracing?)
+    decode_result_response(body, query, tracing_id, Keyword.put(options, :atom_keys?, atom_keys?))
   end
 
   defp decode_inet(<<size, data::size(size)-bytes, buffer::bits>>) do
@@ -578,45 +585,62 @@ defmodule Xandra.Protocol.V3 do
     {address, port, buffer}
   end
 
+  defp decode_tracing_id(body, _tracing? = false) do
+    {body, _tracing_id = nil}
+  end
+
+  defp decode_tracing_id(body, _tracing? = true) do
+    decode_uuid(tracing_id <- body)
+    {body, tracing_id}
+  end
+
   # Void
-  defp decode_result_response(<<0x0001::32-signed>>, _query, _options) do
-    %Xandra.Void{}
+  defp decode_result_response(<<0x0001::32-signed>>, _query, tracing_id, _options) do
+    %Xandra.Void{tracing_id: tracing_id}
   end
 
   # Page
-  defp decode_result_response(<<0x0002::32-signed, buffer::bits>>, query, options) do
+  defp decode_result_response(<<0x0002::32-signed, buffer::bits>>, query, tracing_id, options) do
     page = new_page(query)
     {page, buffer} = decode_metadata(buffer, page, Keyword.fetch!(options, :atom_keys?))
     columns = rewrite_column_types(page.columns, options)
-    %{page | content: decode_page_content(buffer, columns)}
+    %{page | content: decode_page_content(buffer, columns), tracing_id: tracing_id}
   end
 
   # SetKeyspace
-  defp decode_result_response(<<0x0003::32-signed, buffer::bits>>, _query, _options) do
+  defp decode_result_response(<<0x0003::32-signed, buffer::bits>>, _query, tracing_id, _options) do
     decode_string(keyspace <- buffer)
     <<>> = buffer
-    %Xandra.SetKeyspace{keyspace: keyspace}
+    %Xandra.SetKeyspace{keyspace: keyspace, tracing_id: tracing_id}
   end
 
   # Prepared
   defp decode_result_response(
          <<0x0004::32-signed, buffer::bits>>,
          %Prepared{} = prepared,
+         tracing_id,
          options
        ) do
     atom_keys? = Keyword.fetch!(options, :atom_keys?)
     decode_string(id <- buffer)
     {%{columns: bound_columns}, buffer} = decode_metadata(buffer, %Page{}, atom_keys?)
     {%{columns: result_columns}, <<>>} = decode_metadata(buffer, %Page{}, atom_keys?)
-    %{prepared | id: id, bound_columns: bound_columns, result_columns: result_columns}
+
+    %{
+      prepared
+      | id: id,
+        bound_columns: bound_columns,
+        result_columns: result_columns,
+        tracing_id: tracing_id
+    }
   end
 
   # SchemaChange
-  defp decode_result_response(<<0x0005::32-signed, buffer::bits>>, _query, _options) do
+  defp decode_result_response(<<0x0005::32-signed, buffer::bits>>, _query, tracing_id, _options) do
     decode_string(effect <- buffer)
     decode_string(target <- buffer)
     options = decode_change_options(buffer, target)
-    %Xandra.SchemaChange{effect: effect, target: target, options: options}
+    %Xandra.SchemaChange{effect: effect, target: target, options: options, tracing_id: tracing_id}
   end
 
   # Since SELECT statements are not allowed in BATCH queries, there's no need to

--- a/lib/xandra/schema_change.ex
+++ b/lib/xandra/schema_change.ex
@@ -20,11 +20,12 @@ defmodule Xandra.SchemaChange do
 
   """
 
-  defstruct [:effect, :target, :options]
+  defstruct [:effect, :target, :options, :tracing_id]
 
   @type t :: %__MODULE__{
           effect: String.t(),
           target: String.t(),
-          options: map
+          options: map,
+          tracing_id: binary | nil
         }
 end

--- a/lib/xandra/schema_change.ex
+++ b/lib/xandra/schema_change.ex
@@ -18,6 +18,9 @@ defmodule Xandra.SchemaChange do
         keyspace where the change happened and `subject` is the name of what
         changed (so the name of the changed table or type)
 
+    * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
+      or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
+
   """
 
   defstruct [:effect, :target, :options, :tracing_id]

--- a/lib/xandra/set_keyspace.ex
+++ b/lib/xandra/set_keyspace.ex
@@ -6,9 +6,10 @@ defmodule Xandra.SetKeyspace do
   was set through the executed `USE` query.
   """
 
-  defstruct [:keyspace]
+  defstruct [:keyspace, :tracing_id]
 
   @type t :: %__MODULE__{
-          keyspace: String.t()
+          keyspace: String.t(),
+          tracing_id: binary() | nil
         }
 end

--- a/lib/xandra/set_keyspace.ex
+++ b/lib/xandra/set_keyspace.ex
@@ -2,8 +2,14 @@ defmodule Xandra.SetKeyspace do
   @moduledoc """
   A struct that represents the result of a `USE` query.
 
-  This struct only has the `:keyspace` field, which contains the keyspace that
-  was set through the executed `USE` query.
+  These are the public fields of this struct:
+
+    * `:keyspace` - the keyspace (as a binary) that was set through the executed
+      `USE` query.
+
+    * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
+      or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
+
   """
 
   defstruct [:keyspace, :tracing_id]

--- a/lib/xandra/simple.ex
+++ b/lib/xandra/simple.ex
@@ -18,7 +18,7 @@ defmodule Xandra.Simple do
     end
 
     def encode(query, values, options) do
-      Frame.new(:query, Keyword.take(options, [:compressor]))
+      Frame.new(:query, Keyword.take(options, [:compressor, :tracing]))
       |> query.protocol_module.encode_request(%{query | values: values}, options)
       |> Frame.encode(query.protocol_module)
     end

--- a/lib/xandra/void.ex
+++ b/lib/xandra/void.ex
@@ -6,7 +6,7 @@ defmodule Xandra.Void do
   `DELETE`.
   """
 
-  defstruct []
+  defstruct [:tracing_id]
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{tracing_id: binary | nil}
 end

--- a/lib/xandra/void.ex
+++ b/lib/xandra/void.ex
@@ -4,6 +4,12 @@ defmodule Xandra.Void do
 
   This struct is returned as the result of queries such as `INSERT`, `UPDATE`, or
   `DELETE`.
+
+  These are the public fields it contains:
+
+    * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
+      or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
+
   """
 
   defstruct [:tracing_id]

--- a/test/integration/batch_test.exs
+++ b/test/integration/batch_test.exs
@@ -131,7 +131,7 @@ defmodule BatchTest do
     expected =
       ~s/#Xandra.Batch<[type: :logged, / <>
         ~s/queries: [{"INSERT INTO users (id, name) VALUES (1, 'Marge')", []}, / <>
-        ~s/{#Xandra.Prepared<"DELETE FROM users WHERE id = ?">, [2]}]]>/
+        ~s/{#Xandra.Prepared<[statement: "DELETE FROM users WHERE id = ?", tracing_id: nil]>, [2]}]]>/
 
     assert inspect(batch) == expected
   end

--- a/test/integration/prepared_test.exs
+++ b/test/integration/prepared_test.exs
@@ -63,7 +63,9 @@ defmodule PreparedTest do
 
   test "inspecting prepared queries", %{conn: conn} do
     prepared = Xandra.prepare!(conn, "SELECT * FROM users")
-    assert inspect(prepared) == ~s(#Xandra.Prepared<"SELECT * FROM users">)
+
+    assert inspect(prepared) ==
+             ~s(#Xandra.Prepared<[statement: "SELECT * FROM users", tracing_id: nil]>)
   end
 
   test "missing named params raise an error", %{conn: conn} do

--- a/test/integration/results_test.exs
+++ b/test/integration/results_test.exs
@@ -40,7 +40,9 @@ defmodule ResultsTest do
     Xandra.execute!(conn, "CREATE TABLE users (name text PRIMARY KEY)")
     Xandra.execute!(conn, "INSERT INTO users (name) VALUES ('Jeff')")
     %Xandra.Page{} = page = Xandra.execute!(conn, "SELECT * FROM users")
-    assert inspect(page) == ~s(#Xandra.Page<[rows: [%{"name" => "Jeff"}], more_pages?: false]>)
+
+    assert inspect(page) ==
+             ~s(#Xandra.Page<[rows: [%{"name" => "Jeff"}], tracing_id: nil, more_pages?: false]>)
   end
 
   describe "SCHEMA_CHANGE updates since native protocol v4" do

--- a/test/integration/tracing_test.exs
+++ b/test/integration/tracing_test.exs
@@ -1,0 +1,74 @@
+defmodule TracingTest do
+  use XandraTest.IntegrationCase
+
+  alias Xandra.Batch
+
+  setup_all %{keyspace: keyspace, start_options: start_options} do
+    {:ok, conn} = Xandra.start_link(start_options)
+    Xandra.execute!(conn, "USE #{keyspace}")
+
+    statement = "CREATE TABLE users (id int, name text, PRIMARY KEY (id))"
+    Xandra.execute!(conn, statement)
+
+    :ok
+  end
+
+  setup %{conn: conn} do
+    Xandra.execute!(conn, "TRUNCATE users")
+    :ok
+  end
+
+  describe "tracing enabled in each possible response" do
+    test "Xandra.Page", %{conn: conn} do
+      page = Xandra.execute!(conn, "SELECT * FROM users", [], tracing: true)
+      assert is_binary(page.tracing_id)
+    end
+
+    test "Xandra.SetKeyspace", %{conn: conn} do
+      set_keyspace = Xandra.execute!(conn, "USE system", [], tracing: true)
+      assert is_binary(set_keyspace.tracing_id)
+    end
+
+    test "Xandra.SchemaChange", %{conn: conn} do
+      statement = "CREATE TABLE schema_change_with_tracing (id int, name text, PRIMARY KEY (id))"
+      schema_change = Xandra.execute!(conn, statement, [], tracing: true)
+      assert is_binary(schema_change.tracing_id)
+    end
+
+    test "Xandra.Void", %{conn: conn} do
+      void = Xandra.execute!(conn, "TRUNCATE users", [], tracing: true)
+      assert is_binary(void.tracing_id)
+    end
+
+    test "Xandra.Prepared", %{conn: conn} do
+      prepared = Xandra.prepare!(conn, "USE system", tracing: true)
+      assert is_binary(prepared.tracing_id)
+    end
+  end
+
+  @tag :focus
+  test "tracing enabled when executing simple, prepared, and batch queryes",
+       %{conn: conn, keyspace: keyspace} do
+    result = Xandra.execute!(conn, "USE system", [], tracing: true)
+    assert is_binary(result.tracing_id)
+
+    prepared = Xandra.prepare!(conn, "USE system")
+    result = Xandra.execute!(conn, prepared, [], tracing: true)
+    assert is_binary(result.tracing_id)
+
+    batch = Batch.new(:logged) |> Batch.add("DELETE FROM #{keyspace}.users WHERE id = 1")
+    result = Xandra.execute!(conn, batch, tracing: true)
+    assert is_binary(result.tracing_id)
+  end
+
+  test "tracing a query and reading its trace", %{conn: conn} do
+    result = Xandra.execute!(conn, "USE system", [], tracing: true)
+
+    statement = "SELECT * FROM system_traces.events WHERE session_id = ?"
+    trace_events_page = Xandra.execute!(conn, statement, [{"uuid", result.tracing_id}])
+
+    assert [parsing_event, preparing_event] = Enum.to_list(trace_events_page)
+    assert parsing_event["activity"] == "Parsing USE system"
+    assert preparing_event["activity"] == "Preparing statement"
+  end
+end

--- a/test/integration/tracing_test.exs
+++ b/test/integration/tracing_test.exs
@@ -46,7 +46,6 @@ defmodule TracingTest do
     end
   end
 
-  @tag :focus
   test "tracing enabled when executing simple, prepared, and batch queryes",
        %{conn: conn, keyspace: keyspace} do
     result = Xandra.execute!(conn, "USE system", [], tracing: true)

--- a/test/integration/tracing_test.exs
+++ b/test/integration/tracing_test.exs
@@ -66,6 +66,6 @@ defmodule TracingTest do
     statement = "SELECT * FROM system_traces.events WHERE session_id = ?"
 
     assert {:ok, _trace_events_page} =
-             Xandra.execute!(conn, statement, [{"uuid", result.tracing_id}])
+             Xandra.execute(conn, statement, [{"uuid", result.tracing_id}])
   end
 end

--- a/test/integration/tracing_test.exs
+++ b/test/integration/tracing_test.exs
@@ -64,10 +64,8 @@ defmodule TracingTest do
     result = Xandra.execute!(conn, "USE system", [], tracing: true)
 
     statement = "SELECT * FROM system_traces.events WHERE session_id = ?"
-    trace_events_page = Xandra.execute!(conn, statement, [{"uuid", result.tracing_id}])
 
-    assert [parsing_event, preparing_event] = Enum.to_list(trace_events_page)
-    assert parsing_event["activity"] == "Parsing USE system"
-    assert preparing_event["activity"] == "Preparing statement"
+    assert {:ok, _trace_events_page} =
+             Xandra.execute!(conn, statement, [{"uuid", result.tracing_id}])
   end
 end


### PR DESCRIPTION
Closes #161.

This PR adds support for tracing (with the `:tracing` option) and adds a `:tracing_id` field to each result struct (page, prepared, schema change, void, set keyspace).