### PR TITLE
Declare uuid_format and timeuuid_format as breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ __Breaking changes__:
 * Add encryption support through the `:encryption` option.
 * Add the `:decimal_format` option to return decimals as tuples or [`Decimal`](https://github.com/ericmj/decimal) structs. If you want to use `decimal_format: :decimal` you have to specify [decimal](https://github.com/ericmj/decimal) as a dependency.
 * Add the `:default_consistency` option to provide a connection-wide default consistency.
-* Add the `:uuid_format` and `:timeuuid_format` options to return UUIDs as binaries or human-readable strings.
 
 __Breaking changes__:
 
+* Add the `:uuid_format` and `:timeuuid_format` options to return UUIDs as binaries or human-readable strings. This is a breaking change because the by default it is set to `:string`. If you want to keep the previous behaviour, pass `uuid_format: :binary` or `timeuuid_format: :binary` to `Xandra.execute/3/4`.
 * Remove support for the `:pool` option in Xandra. Now the pool of connections is always a pool with size configurable by `:pool_size`.
 * Add `Xandra.Cluster` as a separate module with an API that mirrors `Xandra`, instead of as a DBConnection pool.
 * Bump the Elixir requirement to ~> 1.6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ __Breaking changes__:
 
 __Breaking changes__:
 
-* Add the `:uuid_format` and `:timeuuid_format` options to return UUIDs as binaries or human-readable strings. This is a breaking change because the by default it is set to `:string`. If you want to keep the previous behaviour, pass `uuid_format: :binary` or `timeuuid_format: :binary` to `Xandra.execute/3/4`.
+* Add the `:uuid_format` and `:timeuuid_format` options to return UUIDs as binaries or human-readable strings. This is a breaking change because the default changed to `:string`. If you want to keep the previous behaviour, pass `uuid_format: :binary` or `timeuuid_format: :binary` to `Xandra.execute/3/4`.
 * Remove support for the `:pool` option in Xandra. Now the pool of connections is always a pool with size configurable by `:pool_size`.
 * Add `Xandra.Cluster` as a separate module with an API that mirrors `Xandra`, instead of as a DBConnection pool.
 * Bump the Elixir requirement to ~> 1.6.


### PR DESCRIPTION
The types in which uuids and timeuuids are returned from `Xandra.execute()` changed: In `v0.10.1` they where returned as binaries, in `0.11.0` they are returned as strings (by default). This should be noted as a breaking change in the Changelog.

In `v0.10.1`:

```
$ iex -S mix
iex(1)> Application.spec(:xandra)[:vsn]
'0.10.1'
iex(2)> {:ok, conn} = Xandra.start_link()
iex(3)> Xandra.execute(conn, "CREATE KEYSPACE test WITH replication = {'class' : 'SimpleStrategy', 
iex(4)> Xandra.execute(conn, "CREATE TABLE test.test (id uuid PRIMARY KEY, field text)")
iex(5)> Xandra.execute(conn, "INSERT INTO test.test (id, field) VALUES (13813fb0-1dd2-11b2-800a-00000000000d, 'foobar')")
iex(6)> Xandra.execute(conn, "SELECT * FROM test.test") |> elem(1) |> Enum.to_list
[
  %{
    "field" => "foobar",
    "id" => <<19, 129, 63, 176, 29, 210, 17, 178, 128, 10, 0, 0, 0, 0, 0, 13>>
  }
]
```

In `v0.11.0`:

```
$ iex -S mix
iex(1)> Application.spec(:xandra)[:vsn]
'0.11.0'
iex(2)> {:ok, conn} = Xandra.start_link()
iex(3)> Xandra.execute(conn, "CREATE KEYSPACE test WITH replication = {'class' : 'SimpleStrategy', iex(4)> Xandra.execute(conn, "CREATE TABLE test.test (id uuid PRIMARY KEY, field text)")
iex(5)> Xandra.execute(conn, "INSERT INTO test.test (id, field) VALUES (13813fb0-1dd2-11b2-800a-00000000000d, 'foobar')")
iex(6)> Xandra.execute(conn, "SELECT * FROM test.test") |> elem(1) |> Enum.to_list
[%{"field" => "foobar", "id" => "13813fb0-1dd2-11b2-800a-00000000000d"}]
```