### PR TITLE
Fix Xandra.Cluster reconnect

### DIFF
--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -112,7 +112,9 @@ defmodule Xandra.Cluster.ControlConnection do
     {:connect, :reconnect, %{state | socket: nil, buffer: <<>>}}
   end
 
-  defp report_active(%{new: false} = state) do
+  defp report_active(%{new: false, cluster: cluster, address: address} = state) do
+    status_change = %Xandra.Cluster.StatusChange{effect: "UP", address: address}
+    Xandra.Cluster.update(cluster, status_change)
     {:ok, state}
   end
 

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -113,8 +113,7 @@ defmodule Xandra.Cluster.ControlConnection do
   end
 
   defp report_active(%{new: false, cluster: cluster, address: address} = state) do
-    status_change = %Xandra.Cluster.StatusChange{effect: "UP", address: address}
-    Xandra.Cluster.update(cluster, status_change)
+    Xandra.Cluster.update(cluster, {:control_connection_established, address})
     {:ok, state}
   end
 


### PR DESCRIPTION
Fix for #118. 

I re-used the `Xandra.Cluster.StatusChange` struct in my implementation as it required the smallest amount of change. I think semantically it fits (a successful connection is equivalent to `UP`) but it breaks the mapping of received events to the structs. Please feel free to change this in any way you want!

I also did not touch the code path dealing with the `STATUS_CHANGE=UP` event. I think this can still be useful as it might be faster than re-establishing the control connection (depending on the backoff timing). 