### PR TITLE
Make the connection aware of the current keyspace

### DIFF
--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -110,8 +110,8 @@ defmodule Xandra.Batch do
       |> Frame.encode(batch.protocol_module)
     end
 
-    def decode(batch, %Frame{} = frame, _options) do
-      batch.protocol_module.decode_response(frame, batch)
+    def decode(_batch, response, _options) do
+      response
     end
 
     def describe(batch, _options) do

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -3,7 +3,7 @@ defmodule Xandra.Connection do
 
   use DBConnection
 
-  alias Xandra.{Batch, ConnectionError, Prepared, Frame, Simple}
+  alias Xandra.{Batch, ConnectionError, Prepared, Frame, Simple, SetKeyspace}
   alias __MODULE__.Utils
 
   @default_timeout 5_000
@@ -17,7 +17,8 @@ defmodule Xandra.Connection do
     :compressor,
     :default_consistency,
     :atom_keys?,
-    :protocol_module
+    :protocol_module,
+    :current_keyspace
   ]
 
   @impl true
@@ -49,7 +50,8 @@ defmodule Xandra.Connection do
           compressor: compressor,
           default_consistency: default_consistency,
           atom_keys?: atom_keys?,
-          protocol_module: protocol_module
+          protocol_module: protocol_module,
+          current_keyspace: nil
         }
 
         with {:ok, supported_options} <-
@@ -121,7 +123,8 @@ defmodule Xandra.Connection do
     prepared = %{
       prepared
       | default_consistency: state.default_consistency,
-        protocol_module: state.protocol_module
+        protocol_module: state.protocol_module,
+        keyspace: state.current_keyspace
     }
 
     force? = Keyword.fetch!(options, :force)
@@ -185,9 +188,15 @@ defmodule Xandra.Connection do
 
     with :ok <- state.transport.send(socket, payload),
          {:ok, %Frame{} = frame} <-
-           Utils.recv_frame(state.transport, socket, state.protocol_module, compressor) do
-      {:ok, query, %{frame | atom_keys?: atom_keys?}, state}
+           Utils.recv_frame(state.transport, socket, state.protocol_module, compressor),
+         frame = %{frame | atom_keys?: atom_keys?},
+         %SetKeyspace{keyspace: keyspace} = response <-
+           state.protocol_module.decode_response(frame, query, options) do
+      {:ok, query, response, %{state | current_keyspace: keyspace}}
     else
+      %_{} = response ->
+        {:ok, query, response, state}
+
       {:error, reason} ->
         {:disconnect, ConnectionError.new("execute", reason), state}
     end

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -19,7 +19,8 @@ defmodule Xandra.Prepared do
     :result_columns,
     :default_consistency,
     :protocol_module,
-    :tracing_id
+    :tracing_id,
+    :keyspace
   ]
 
   @type t :: %__MODULE__{
@@ -30,7 +31,8 @@ defmodule Xandra.Prepared do
           result_columns: list | nil,
           default_consistency: atom | nil,
           protocol_module: module | nil,
-          tracing_id: binary | nil
+          tracing_id: binary | nil,
+          keyspace: binary | nil
         }
 
   @doc false
@@ -66,8 +68,8 @@ defmodule Xandra.Prepared do
       |> Frame.encode(prepared.protocol_module)
     end
 
-    def decode(prepared, %Frame{} = frame, options) do
-      prepared.protocol_module.decode_response(frame, prepared, options)
+    def decode(_prepared, response, _options) do
+      response
     end
 
     def describe(prepared, _options) do

--- a/lib/xandra/prepared/cache.ex
+++ b/lib/xandra/prepared/cache.ex
@@ -16,17 +16,22 @@ defmodule Xandra.Prepared.Cache do
       statement: statement,
       id: id,
       bound_columns: bound_columns,
-      result_columns: result_columns
+      result_columns: result_columns,
+      keyspace: keyspace
     } = prepared
 
-    :ets.insert(table, {statement, id, bound_columns, result_columns})
+    key = {statement, keyspace}
+
+    :ets.insert(table, {key, id, bound_columns, result_columns})
     :ok
   end
 
   @spec lookup(t, Prepared.t()) :: {:ok, Prepared.t()} | :error
-  def lookup(table, %Prepared{statement: statement} = prepared) do
-    case :ets.lookup(table, statement) do
-      [{^statement, id, bound_columns, result_columns}] ->
+  def lookup(table, %Prepared{statement: statement, keyspace: keyspace} = prepared) do
+    key = {statement, keyspace}
+
+    case :ets.lookup(table, key) do
+      [{^key, id, bound_columns, result_columns}] ->
         {:ok, %{prepared | id: id, bound_columns: bound_columns, result_columns: result_columns}}
 
       [] ->

--- a/lib/xandra/simple.ex
+++ b/lib/xandra/simple.ex
@@ -23,8 +23,8 @@ defmodule Xandra.Simple do
       |> Frame.encode(query.protocol_module)
     end
 
-    def decode(query, %Frame{} = frame, options) do
-      query.protocol_module.decode_response(frame, query, options)
+    def decode(_query, response, _options) do
+      response
     end
 
     def describe(query, _options) do

--- a/test/integration/use_test.exs
+++ b/test/integration/use_test.exs
@@ -1,0 +1,67 @@
+defmodule UseTest do
+  use XandraTest.IntegrationCase, async: true
+
+  setup_all %{keyspace: keyspace, start_options: start_options} do
+    {:ok, conn} = Xandra.start_link(start_options)
+
+    other_keyspace = keyspace <> "_2"
+    Xandra.execute!(conn, "DROP KEYSPACE IF EXISTS #{other_keyspace}")
+
+    statement = """
+    CREATE KEYSPACE #{other_keyspace}
+    WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}
+    """
+
+    Xandra.execute!(conn, statement)
+
+    keyspaces = [keyspace, other_keyspace]
+
+    for keyspace <- keyspaces do
+      statement = "CREATE TABLE #{keyspace}.whoami (whoami text, PRIMARY KEY (whoami))"
+
+      Xandra.execute!(conn, statement)
+
+      statement = "INSERT INTO #{keyspace}.whoami (whoami) VALUES (:whoami)"
+      params = %{"whoami" => {"text", keyspace}}
+      Xandra.execute!(conn, statement, params)
+    end
+
+    on_exit(fn ->
+      {:ok, conn} = Xandra.start_link(start_options)
+
+      for keyspace <- keyspaces do
+        Xandra.execute!(conn, "DROP KEYSPACE IF EXISTS #{keyspace}")
+      end
+    end)
+
+    [keyspaces: keyspaces]
+  end
+
+  test "use statement followed by an execute statement", %{conn: conn, keyspaces: keyspaces} do
+    for keyspace <- keyspaces do
+      statement = "USE #{keyspace}"
+
+      assert %Xandra.SetKeyspace{keyspace: ^keyspace} = Xandra.execute!(conn, statement)
+
+      statement = "SELECT whoami FROM whoami"
+
+      page = Xandra.execute!(conn, statement, %{})
+
+      assert Enum.to_list(page) == [%{"whoami" => keyspace}]
+    end
+  end
+
+  test "use statement followed by a prepared statement", %{conn: conn, keyspaces: keyspaces} do
+    for keyspace <- keyspaces do
+      statement = "USE #{keyspace}"
+
+      assert %Xandra.SetKeyspace{keyspace: ^keyspace} = Xandra.execute!(conn, statement)
+
+      statement = "SELECT whoami FROM whoami"
+      prepared = Xandra.prepare!(conn, statement)
+
+      page = Xandra.execute!(conn, prepared)
+      assert Enum.to_list(page) == [%{"whoami" => keyspace}]
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -21,7 +21,12 @@ defmodule XandraTest.IntegrationCase do
             default_start_options: @default_start_options
           ] do
       setup_all do
-        keyspace = "xandra_test_" <> String.replace(inspect(__MODULE__), ".", "")
+        module_suffix =
+          inspect(__MODULE__)
+          |> String.replace(".", "")
+          |> String.downcase()
+
+        keyspace = "xandra_test_" <> module_suffix
 
         start_options = Keyword.merge(unquote(default_start_options), unquote(start_options))
         case_template = unquote(case_template)


### PR DESCRIPTION
Use the keyspace information to add it to `%Prepared{}` structs so that it can be used together with the statement as key in the prepared cache. This avoids erroneously using queries that were prepared against another keyspace.

To do so, response decoding has been moved inside the connection, akin to what was already done in `handle_prepare` to populate the prepared cache. The decode function in query structs is now simply an identity since the result gets there already decoded.

This also includes a minor fixup in the keyspace returned by `setup_all` by `IntegrationCase`.

Fix #179 