### PR TITLE
Rescue and return ConnectionError from DBConnection calls

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -886,7 +886,7 @@ defmodule Xandra do
   """
   @spec run(conn, keyword, (conn -> result)) :: result when result: var
   def run(conn, options \\ [], fun) when is_function(fun, 1) do
-    safe_call(fn ->DBConnection.run(conn, fun, options) end)
+    safe_call(fn -> DBConnection.run(conn, fun, options) end)
   end
 
   defp reprepare_queries(conn, [%Simple{} | rest], options) do
@@ -963,12 +963,14 @@ defmodule Xandra do
         {:ok, _query, %Error{reason: :unprepared}} ->
           # We can ignore the newly returned prepared query since it will have the
           # same id of the query we are repreparing.
-          case safe_call(fn -> DBConnection.prepare_execute(
-                 conn,
-                 prepared,
-                 params,
-                 Keyword.put(options, :force, true)
-               ) end) do
+          case safe_call(fn ->
+                 DBConnection.prepare_execute(
+                   conn,
+                   prepared,
+                   params,
+                   Keyword.put(options, :force, true)
+                 )
+               end) do
             {:ok, _prepared, %Error{} = error} ->
               {:error, error}
 

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -1057,7 +1057,7 @@ defmodule Xandra do
       db_connection_fun.()
     rescue
       # DBConnection functions can sometimes raise DBConnection.ConnectionError instead of returning it.
-      err in DBConnection.ConnectionError -> {:error, err}
+      error in DBConnection.ConnectionError -> {:error, error}
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/lexhide/xandra/issues/183

This wraps each call to `DBConnection` in a `safe_call` function that rescues and returns any `DBConnection.ConnectionError`s.