### PR TITLE
Add Support for Custom Payload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,25 @@ jobs:
     - <<: *test-scylla
       env: SCYLLA_VERSION=2.0.0
 
+    - test-cosmos:
+      stage: test cosmos
+      os: windows
+      language: shell
+      install:
+        - choco install --no-progress -y elixir --version 1.10.3
+        - curl -Lso cosmosdb-emulator-install.msi https://aka.ms/cosmosdb-emulator
+        - msiexec /i cosmosdb-emulator-install.msi /quiet /qn /norestart
+        - mix deps.get
+        - mix deps.compile
+      before_script:
+        - powershell test/windows/cosmosdb-start-wait.ps1
+      script: mix test.cosmosdb
+      after_script:
+        - powershell test/windows/cosmosdb-stop-wait.ps1
+      env:
+        - CASSANDRA_IS_COSMOSDB=true
+        - CASSANDRA_NATIVE_PROTOCOL=v4
+
     - stage: check formatted
       script: mix format --check-formatted
       before_install: skip
@@ -66,3 +85,4 @@ stages:
   - check formatted
   - test
   - test scylla
+  - test cosmos

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,7 @@ jobs:
       language: shell
       install:
         - choco install --no-progress -y elixir --version 1.10.3
-        - curl -Lso cosmosdb-emulator-install.msi https://aka.ms/cosmosdb-emulator
-        - msiexec /i cosmosdb-emulator-install.msi /quiet /qn /norestart
+        - powershell test/windows/cosmosdb-download-install.ps1
         - mix deps.get
         - mix deps.compile
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,14 +62,17 @@ jobs:
       language: shell
       install:
         - choco install --no-progress -y elixir --version 1.10.3
-        - powershell test/windows/cosmosdb-download-install.ps1
+        - export PATH=/c/ProgramData/chocolatey/lib/Elixir/bin:$PATH
+        - mix local.hex --force
+        - mix local.rebar --force
+        - powershell -executionpolicy bypass -file test/windows/cosmosdb-download-install.ps1
         - mix deps.get
         - mix deps.compile
       before_script:
-        - powershell test/windows/cosmosdb-start-wait.ps1
-      script: mix test.cosmosdb
+        - powershell -executionpolicy bypass -file test/windows/cosmosdb-start-wait.ps1
+      script: mix test.cosmosdb --max-cases 1
       after_script:
-        - powershell test/windows/cosmosdb-stop-wait.ps1
+        - powershell -executionpolicy bypass -file test/windows/cosmosdb-stop-wait.ps1
       env:
         - CASSANDRA_IS_COSMOSDB=true
         - CASSANDRA_NATIVE_PROTOCOL=v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.14.0
+
+* Add support for custom payload as defined in protocol version 4. This adds support for Azure Cosmos DB.
+
 ## v0.13.1
 
 * Fix the spec for `Xandra.Batch.add/3`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the `:xandra` dependency to your `mix.exs` file:
 
 ```elixir
 def deps() do
-  [{:xandra, "~> 0.11"}]
+  [{:xandra, "~> 0.14"}]
 end
 ```
 
@@ -81,6 +81,10 @@ page_stream
 
 Xandra supports [Scylla][scylladb] (version `2.x`) without the need to do anything in particular.
 
+## Azure Cosmos DB support
+
+Xandra supports [Azure Cosmos DB][cosmosdb] when using v4 of the CQL protocol.
+
 ## Contributing
 
 To run tests, you will need [Docker][docker] installed on your machine. This repository uses [`docker-compose`][docker-compose] to run multiple Cassandra instances in parallel on different ports to test different features (such as authentication or SSL encryption). To run normal tests, do this from the root of the project:
@@ -118,3 +122,4 @@ Xandra is released under the ISC license, see the [LICENSE](LICENSE) file.
 [docker]: https://www.docker.com
 [docker-compose]: https://docs.docker.com/compose/
 [scylladb]: https://www.scylladb.com/
+[cosmosdb]: https://azure.microsoft.com/services/cosmos-db/

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -445,6 +445,10 @@ defmodule Xandra do
       given query and sets the `tracing_id` field in the returned prepared
       query. See the "Tracing" option in `execute/4`. Defaults to `false`.
 
+    * `:custom_payload` - (Keywords) custom payload to be sent along with the
+      request (only protocol version 4). See the "Custom Payload" option in
+      `execute/4`. By default, this option is not present.
+
   ## Prepared queries cache
 
   Since Cassandra prepares queries on a per-node basis (and not on a
@@ -656,6 +660,11 @@ defmodule Xandra do
       `tracing_id` field on the result of the query. See the "Tracing" section
       below. Defaults to `false`.
 
+    * `:custom_payload` - (Keywords) custom payload to be sent along with the
+      request (only protocol version 4). Keys must be strings, values must be
+      binaries. See the "Custom Payload" section below. By default, this option
+      is not present.
+
     * `:date_format` - (`:date` or `:integer`) controls the format in which
       dates are returned. When set to `:integer` the returned value is
       a number of days from the Unix epoch, a date struct otherwise.
@@ -806,6 +815,22 @@ defmodule Xandra do
   Note that tracing is an expensive operation for Cassandra that puts load on
   executing queries. This is why this option is only supported *per-query* in
   `execute/4` instead of connection-wide.
+
+  Also note that not all Cassandra compatible servers support tracing.
+
+  ## Custom Payload
+
+  Some Cassandra compatible servers use custom payload to transmit additional
+  information through requests and responses. This feature is most prominently
+  used by Microsoft's Azure Cosomos DB where it is used in responses for
+  tracking request costs.
+
+  In Xandra, you can send custom payload with the `:custom_payload` option and
+  receive custom payload in all response structs (e.g. `Xandra.Page`).
+
+  Note that this feature is exclusive to protocol v4 and will be silently
+  ignored when using protocol v3. Also, as per specification, currently only
+  QUERY, PREPARE, EXECUTE and BATCH requests support outgoing payload.
   """
   @spec execute(conn, statement | Prepared.t(), values, keyword) ::
           {:ok, result} | {:error, error}

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -13,7 +13,8 @@ defmodule Xandra.Batch do
   alias Xandra.{Prepared, Simple}
 
   @enforce_keys [:type]
-  defstruct @enforce_keys ++ [queries: [], default_consistency: nil, protocol_module: nil, custom_payload: nil]
+  defstruct @enforce_keys ++
+              [queries: [], default_consistency: nil, protocol_module: nil, custom_payload: nil]
 
   @type type :: :logged | :unlogged | :counter
 

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -139,7 +139,9 @@ defmodule Xandra.Connection do
 
       :error ->
         frame_options =
-          options |> Keyword.take([:tracing, :custom_payload]) |> Keyword.put(:compressor, compressor)
+          options
+          |> Keyword.take([:tracing, :custom_payload])
+          |> Keyword.put(:compressor, compressor)
 
         payload =
           Frame.new(:prepare, frame_options)

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -139,7 +139,7 @@ defmodule Xandra.Connection do
 
       :error ->
         frame_options =
-          options |> Keyword.take([:tracing]) |> Keyword.put(:compressor, compressor)
+          options |> Keyword.take([:tracing, :custom_payload]) |> Keyword.put(:compressor, compressor)
 
         payload =
           Frame.new(:prepare, frame_options)

--- a/lib/xandra/frame.ex
+++ b/lib/xandra/frame.ex
@@ -101,9 +101,11 @@ defmodule Xandra.Frame do
       body: body
     } = frame
 
-    custom_payload? = custom_payload != nil and
-      kind in [:query, :prepare, :execute, :batch] and
-      Map.fetch!(@supports_custom_payload, protocol_module)
+    custom_payload? =
+      custom_payload != nil and
+        kind in [:query, :prepare, :execute, :batch] and
+        Map.fetch!(@supports_custom_payload, protocol_module)
+
     body = maybe_compress_body(compressor, body)
 
     [

--- a/lib/xandra/page.ex
+++ b/lib/xandra/page.ex
@@ -23,6 +23,10 @@ defmodule Xandra.Page do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * `:custom_payload` - the custom payload sent along with the response (only
+      protocol version 4). This is used by Azure Cosmos DB to inform about the
+      RequestCharge, for example. See the "Custom Payload" section in `Xandra.execute/4`.
+
   ## Examples
 
       statement = "SELECT name, age FROM users"
@@ -33,7 +37,7 @@ defmodule Xandra.Page do
 
   """
 
-  defstruct [:content, :columns, :paging_state, :tracing_id]
+  defstruct [:content, :columns, :paging_state, :tracing_id, :custom_payload]
 
   @type paging_state :: binary | nil
 
@@ -41,7 +45,8 @@ defmodule Xandra.Page do
           content: list,
           columns: nonempty_list,
           paging_state: paging_state,
-          tracing_id: binary | nil
+          tracing_id: binary | nil,
+          custom_payload: [{String.t, binary}] | nil
         }
 
   defimpl Enumerable do
@@ -86,6 +91,7 @@ defmodule Xandra.Page do
       properties = [
         rows: Enum.to_list(page),
         tracing_id: page.tracing_id,
+        custom_payload: page.custom_payload,
         more_pages?: page.paging_state != nil
       ]
 

--- a/lib/xandra/page.ex
+++ b/lib/xandra/page.ex
@@ -46,7 +46,7 @@ defmodule Xandra.Page do
           columns: nonempty_list,
           paging_state: paging_state,
           tracing_id: binary | nil,
-          custom_payload: [{String.t, binary}] | nil
+          custom_payload: [{String.t(), binary}] | nil
         }
 
   defimpl Enumerable do

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -35,7 +35,7 @@ defmodule Xandra.Prepared do
           default_consistency: atom | nil,
           protocol_module: module | nil,
           tracing_id: binary | nil,
-          custom_payload: [{String.t, binary}] | nil,
+          custom_payload: [{String.t(), binary}] | nil
         }
 
   @doc false

--- a/lib/xandra/protocol/v4.ex
+++ b/lib/xandra/protocol/v4.ex
@@ -572,7 +572,12 @@ defmodule Xandra.Protocol.V4 do
           Xandra.result() | Prepared.t()
   def decode_response(frame, query \\ nil, options \\ [])
 
-  def decode_response(%Frame{kind: :error, body: body, warning: warning?}, _query, _options) do
+  def decode_response(
+        %Frame{kind: :error, body: body, custom_payload: custom_payload?, warning: warning?},
+        _query,
+        _options
+      ) do
+    {body, _} = decode_custom_payload(body, custom_payload?)
     body = decode_warnings(body, warning?)
     {reason, buffer} = decode_error_reason(body)
     Error.new(reason, decode_error_message(reason, buffer))

--- a/lib/xandra/schema_change.ex
+++ b/lib/xandra/schema_change.ex
@@ -21,14 +21,19 @@ defmodule Xandra.SchemaChange do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * `:custom_payload` - the custom payload sent along with the response (only
+      protocol version 4). This is used by Azure Cosmos DB to inform about the
+      RequestCharge, for example. See the "Custom Payload" section in `Xandra.execute/4`.
+
   """
 
-  defstruct [:effect, :target, :options, :tracing_id]
+  defstruct [:effect, :target, :options, :tracing_id, :custom_payload]
 
   @type t :: %__MODULE__{
           effect: String.t(),
           target: String.t(),
           options: map,
-          tracing_id: binary | nil
+          tracing_id: binary | nil,
+          custom_payload: list({String.t(), binary()}) | nil
         }
 end

--- a/lib/xandra/set_keyspace.ex
+++ b/lib/xandra/set_keyspace.ex
@@ -10,12 +10,17 @@ defmodule Xandra.SetKeyspace do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * `:custom_payload` - the custom payload sent along with the response (only
+      protocol version 4). This is used by Azure Cosmos DB to inform about the
+      RequestCharge, for example. See the "Custom Payload" section in `Xandra.execute/4`.
+
   """
 
-  defstruct [:keyspace, :tracing_id]
+  defstruct [:keyspace, :tracing_id, :custom_payload]
 
   @type t :: %__MODULE__{
           keyspace: String.t(),
-          tracing_id: binary() | nil
+          tracing_id: binary() | nil,
+          custom_payload: list({String.t(), binary()}) | nil
         }
 end

--- a/lib/xandra/simple.ex
+++ b/lib/xandra/simple.ex
@@ -18,7 +18,7 @@ defmodule Xandra.Simple do
     end
 
     def encode(query, values, options) do
-      Frame.new(:query, Keyword.take(options, [:compressor, :tracing]))
+      Frame.new(:query, Keyword.take(options, [:compressor, :tracing, :custom_payload]))
       |> query.protocol_module.encode_request(%{query | values: values}, options)
       |> Frame.encode(query.protocol_module)
     end

--- a/lib/xandra/void.ex
+++ b/lib/xandra/void.ex
@@ -10,9 +10,13 @@ defmodule Xandra.Void do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * `:custom_payload` - the custom payload sent along with the response (only
+      protocol version 4). This is used by Azure Cosmos DB to inform about the
+      RequestCharge, for example. See the "Custom Payload" section in `Xandra.execute/4`.
+
   """
 
-  defstruct [:tracing_id]
+  defstruct [:tracing_id, :custom_payload]
 
-  @type t :: %__MODULE__{tracing_id: binary | nil}
+  @type t :: %__MODULE__{tracing_id: binary | nil, custom_payload: [{String.t, binary}] | nil}
 end

--- a/lib/xandra/void.ex
+++ b/lib/xandra/void.ex
@@ -18,5 +18,5 @@ defmodule Xandra.Void do
 
   defstruct [:tracing_id, :custom_payload]
 
-  @type t :: %__MODULE__{tracing_id: binary | nil, custom_payload: [{String.t, binary}] | nil}
+  @type t :: %__MODULE__{tracing_id: binary | nil, custom_payload: [{String.t(), binary}] | nil}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,8 @@ defmodule Xandra.Mixfile do
       # Task aliases
       aliases: [
         "test.scylladb": "test --exclude encryption --exclude cassandra_specific",
-        "test.cosmosdb": "test --exclude encryption --exclude cassandra_specific --exclude authentication --exclude cosmosdb_unsupported"
+        "test.cosmosdb":
+          "test --exclude encryption --exclude cassandra_specific --exclude authentication --exclude cosmosdb_unsupported"
       ],
       preferred_cli_env: ["test.scylladb": :test, "test.cosmosdb": :test],
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Xandra.Mixfile do
 
   @repo_url "https://github.com/lexhide/xandra"
 
-  @version "0.13.1"
+  @version "0.14.0"
 
   def project() do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -17,8 +17,11 @@ defmodule Xandra.Mixfile do
       deps: deps(),
 
       # Task aliases
-      aliases: ["test.scylladb": "test --exclude encryption --exclude cassandra_specific"],
-      preferred_cli_env: ["test.scylladb": :test],
+      aliases: [
+        "test.scylladb": "test --exclude encryption --exclude cassandra_specific",
+        "test.cosmosdb": "test --exclude encryption --exclude cassandra_specific --exclude authentication --exclude cosmosdb_unsupported"
+      ],
+      preferred_cli_env: ["test.scylladb": :test, "test.cosmosdb": :test],
 
       # Dialyzer
       dialyzer: [flags: [:no_contracts]],

--- a/test/integration/batch_test.exs
+++ b/test/integration/batch_test.exs
@@ -129,9 +129,9 @@ defmodule BatchTest do
       |> Batch.add(prepared, [2])
 
     expected =
-      ~s/#Xandra.Batch<[type: :logged, / <>
+      ~s/#Xandra.Batch<[type: :logged, custom_payload: nil, / <>
         ~s/queries: [{"INSERT INTO users (id, name) VALUES (1, 'Marge')", []}, / <>
-        ~s/{#Xandra.Prepared<[statement: "DELETE FROM users WHERE id = ?", tracing_id: nil]>, [2]}]]>/
+        ~s/{#Xandra.Prepared<[statement: "DELETE FROM users WHERE id = ?", tracing_id: nil, custom_payload: nil]>, [2]}]]>/
 
     assert inspect(batch) == expected
   end

--- a/test/integration/clustering_test.exs
+++ b/test/integration/clustering_test.exs
@@ -3,6 +3,10 @@ defmodule ClusteringTest do
 
   import ExUnit.CaptureLog
 
+  # The way Cosmos DB works, clustering is not supported in this form. Any
+  # connection is handled transparently and might undergo internal clustering.
+  @moduletag :cosmosdb_unsupported
+
   def await_connected(cluster, options, fun, tries \\ 4) do
     try do
       Xandra.Cluster.run(cluster, options, fun)

--- a/test/integration/compression_test.exs
+++ b/test/integration/compression_test.exs
@@ -1,6 +1,8 @@
 defmodule CompressionTest do
   use XandraTest.IntegrationCase, async: true
 
+  @moduletag :cosmosdb_unsupported
+
   defmodule Snappy do
     @behaviour Xandra.Compressor
 

--- a/test/integration/datatypes_test.exs
+++ b/test/integration/datatypes_test.exs
@@ -5,24 +5,24 @@ defmodule DataTypesTest do
     statement = """
     CREATE TABLE primitives
     (id int PRIMARY KEY,
-     ascii ascii,
-     bigint bigint,
-     blob blob,
-     boolean boolean,
-     decimal decimal,
-     double double,
-     float float,
-     inet inet,
-     int int,
-     smallint smallint,
-     text text,
-     time time,
-     timestamp timestamp,
-     timeuuid timeuuid,
-     tinyint tinyint,
-     uuid uuid,
-     varchar varchar,
-     varint varint)
+     an_ascii ascii,
+     a_bigint bigint,
+     a_blob blob,
+     a_boolean boolean,
+     a_decimal decimal,
+     a_double double,
+     a_float float,
+     an_inet inet,
+     an_int int,
+     a_smallint smallint,
+     a_text text,
+     a_time time,
+     a_timestamp timestamp,
+     a_timeuuid timeuuid,
+     a_tinyint tinyint,
+     a_uuid uuid,
+     a_varchar varchar,
+     a_varint varint)
     """
 
     Xandra.execute!(conn, statement)
@@ -30,22 +30,22 @@ defmodule DataTypesTest do
     statement = """
     INSERT INTO primitives
     (id,
-     ascii,
-     bigint,
-     blob,
-     boolean,
-     decimal,
-     double,
-     float,
-     inet,
-     int,
-     smallint,
-     text,
-     timeuuid,
-     tinyint,
-     uuid,
-     varchar,
-     varint)
+     an_ascii,
+     a_bigint,
+     a_blob,
+     a_boolean,
+     a_decimal,
+     a_double,
+     a_float,
+     an_inet,
+     an_int,
+     a_smallint,
+     a_text,
+     a_timeuuid,
+     a_tinyint,
+     a_uuid,
+     a_varchar,
+     a_varint)
     VALUES
     (#{"?" |> List.duplicate(17) |> Enum.join(", ")})
     """
@@ -74,22 +74,22 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM primitives WHERE id = 1")
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 1
-    assert Map.fetch!(row, "ascii") == nil
-    assert Map.fetch!(row, "bigint") == nil
-    assert Map.fetch!(row, "blob") == nil
-    assert Map.fetch!(row, "boolean") == nil
-    assert Map.fetch!(row, "decimal") == nil
-    assert Map.fetch!(row, "double") == nil
-    assert Map.fetch!(row, "float") == nil
-    assert Map.fetch!(row, "inet") == nil
-    assert Map.fetch!(row, "int") == nil
-    assert Map.fetch!(row, "smallint") == nil
-    assert Map.fetch!(row, "text") == nil
-    assert Map.fetch!(row, "timeuuid") == nil
-    assert Map.fetch!(row, "tinyint") == nil
-    assert Map.fetch!(row, "uuid") == nil
-    assert Map.fetch!(row, "varchar") == nil
-    assert Map.fetch!(row, "varint") == nil
+    assert Map.fetch!(row, "an_ascii") == nil
+    assert Map.fetch!(row, "a_bigint") == nil
+    assert Map.fetch!(row, "a_blob") == nil
+    assert Map.fetch!(row, "a_boolean") == nil
+    assert Map.fetch!(row, "a_decimal") == nil
+    assert Map.fetch!(row, "a_double") == nil
+    assert Map.fetch!(row, "a_float") == nil
+    assert Map.fetch!(row, "an_inet") == nil
+    assert Map.fetch!(row, "an_int") == nil
+    assert Map.fetch!(row, "a_smallint") == nil
+    assert Map.fetch!(row, "a_text") == nil
+    assert Map.fetch!(row, "a_timeuuid") == nil
+    assert Map.fetch!(row, "a_tinyint") == nil
+    assert Map.fetch!(row, "a_uuid") == nil
+    assert Map.fetch!(row, "a_varchar") == nil
+    assert Map.fetch!(row, "a_varint") == nil
 
     values = [
       {"int", 2},
@@ -114,32 +114,32 @@ defmodule DataTypesTest do
     Xandra.execute!(conn, statement, values)
     page = Xandra.execute!(conn, "SELECT * FROM primitives WHERE id = 2")
     assert [row] = Enum.to_list(page)
-    assert Map.fetch!(row, "ascii") == "ascii"
-    assert Map.fetch!(row, "bigint") == -1_000_000_000
-    assert Map.fetch!(row, "blob") == <<0, 0xFF>>
-    assert Map.fetch!(row, "boolean") == true
-    assert Map.fetch!(row, "decimal") == {1323, -2}
-    assert Map.fetch!(row, "double") == 3.1415
-    assert Map.fetch!(row, "float") == -1.25
-    assert Map.fetch!(row, "inet") == {192, 168, 0, 1}
-    assert Map.fetch!(row, "int") == -42
-    assert Map.fetch!(row, "smallint") == -33
-    assert Map.fetch!(row, "text") == "эликсир"
-    assert Map.fetch!(row, "timeuuid") == "fe2b4360-28c6-11e2-81c1-0800200c9a66"
-    assert Map.fetch!(row, "tinyint") == -21
-    assert Map.fetch!(row, "uuid") == "00b69180-d0e1-11e2-8b8b-0800200c9a66"
-    assert Map.fetch!(row, "varchar") == "тоже эликсир"
-    assert Map.fetch!(row, "varint") == -6_789_065_678_192_312_391_879_827_349
+    assert Map.fetch!(row, "an_ascii") == "ascii"
+    assert Map.fetch!(row, "a_bigint") == -1_000_000_000
+    assert Map.fetch!(row, "a_blob") == <<0, 0xFF>>
+    assert Map.fetch!(row, "a_boolean") == true
+    assert Map.fetch!(row, "a_decimal") == {1323, -2}
+    assert Map.fetch!(row, "a_double") == 3.1415
+    assert Map.fetch!(row, "a_float") == -1.25
+    assert Map.fetch!(row, "an_inet") == {192, 168, 0, 1}
+    assert Map.fetch!(row, "an_int") == -42
+    assert Map.fetch!(row, "a_smallint") == -33
+    assert Map.fetch!(row, "a_text") == "эликсир"
+    assert Map.fetch!(row, "a_timeuuid") == "fe2b4360-28c6-11e2-81c1-0800200c9a66"
+    assert Map.fetch!(row, "a_tinyint") == -21
+    assert Map.fetch!(row, "a_uuid") == "00b69180-d0e1-11e2-8b8b-0800200c9a66"
+    assert Map.fetch!(row, "a_varchar") == "тоже эликсир"
+    assert Map.fetch!(row, "a_varint") == -6_789_065_678_192_312_391_879_827_349
   end
 
   test "zero-byte value for string types", %{conn: conn} do
     statement = """
     CREATE TABLE string_with_zero_bytes
     (id int PRIMARY KEY,
-     ascii ascii,
-     blob blob,
-     text text,
-     varchar varchar)
+     an_ascii ascii,
+     a_blob blob,
+     a_text text,
+     a_varchar varchar)
     """
 
     Xandra.execute!(conn, statement)
@@ -147,10 +147,10 @@ defmodule DataTypesTest do
     statement = """
     INSERT INTO string_with_zero_bytes
     (id,
-     ascii,
-     blob,
-     text,
-     varchar)
+     an_ascii,
+     a_blob,
+     a_text,
+     a_varchar)
     VALUES
     (#{"?" |> List.duplicate(5) |> Enum.join(", ")})
     """
@@ -167,19 +167,19 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM string_with_zero_bytes WHERE id = 1")
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 1
-    assert Map.fetch!(row, "ascii") == ""
-    assert Map.fetch!(row, "blob") == ""
-    assert Map.fetch!(row, "text") == ""
-    assert Map.fetch!(row, "varchar") == ""
+    assert Map.fetch!(row, "an_ascii") == ""
+    assert Map.fetch!(row, "a_blob") == ""
+    assert Map.fetch!(row, "a_text") == ""
+    assert Map.fetch!(row, "a_varchar") == ""
   end
 
   test "calendar types", %{conn: conn} do
     statement = """
     CREATE TABLE festivities
     (id int PRIMARY KEY,
-     date date,
-     time time,
-     timestamp timestamp)
+     a_date date,
+     a_time time,
+     a_timestamp timestamp)
     """
 
     Xandra.execute!(conn, statement)
@@ -187,9 +187,9 @@ defmodule DataTypesTest do
     statement = """
     INSERT INTO festivities
     (id,
-     date,
-     time,
-     timestamp)
+     a_date,
+     a_time,
+     a_timestamp)
     VALUES
     (#{"?" |> List.duplicate(4) |> Enum.join(", ")})
     """
@@ -205,9 +205,9 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM festivities WHERE id = 1")
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 1
-    assert Map.fetch!(row, "date") == nil
-    assert Map.fetch!(row, "time") == nil
-    assert Map.fetch!(row, "timestamp") == nil
+    assert Map.fetch!(row, "a_date") == nil
+    assert Map.fetch!(row, "a_time") == nil
+    assert Map.fetch!(row, "a_timestamp") == nil
 
     datetime = DateTime.from_naive!(~N[2016-05-24 13:26:08.003], "Etc/UTC")
 
@@ -222,9 +222,9 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM festivities WHERE id = 2")
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 2
-    assert Map.fetch!(row, "date") == ~D[2017-09-11]
-    assert Map.fetch!(row, "time") == ~T[20:13:50.000004]
-    assert Map.fetch!(row, "timestamp") == datetime
+    assert Map.fetch!(row, "a_date") == ~D[2017-09-11]
+    assert Map.fetch!(row, "a_time") == ~T[20:13:50.000004]
+    assert Map.fetch!(row, "a_timestamp") == datetime
 
     values = [
       {"int", 3},
@@ -244,20 +244,20 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM festivities WHERE id = 3", [], options)
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 3
-    assert Map.fetch!(row, "date") == 1_358_013_521
-    assert Map.fetch!(row, "time") == 1_358_013_521
-    assert Map.fetch!(row, "timestamp") == -2_167_219_200
+    assert Map.fetch!(row, "a_date") == 1_358_013_521
+    assert Map.fetch!(row, "a_time") == 1_358_013_521
+    assert Map.fetch!(row, "a_timestamp") == -2_167_219_200
   end
 
   test "decimal type with formats", %{conn: conn} do
     statement = """
-    CREATE TABLE decs (id int PRIMARY KEY, decimal decimal)
+    CREATE TABLE decs (id int PRIMARY KEY, a_decimal decimal)
     """
 
     Xandra.execute!(conn, statement)
 
     statement = """
-    INSERT INTO decs (id, decimal) VALUES (?, ?)
+    INSERT INTO decs (id, a_decimal) VALUES (?, ?)
     """
 
     # 95.343
@@ -273,7 +273,7 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM decs WHERE id = 1")
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 1
-    assert Map.fetch!(row, "decimal") == decimal_as_tuple
+    assert Map.fetch!(row, "a_decimal") == decimal_as_tuple
 
     # 95.343
     decimal_as_decimal = Decimal.new(1, 95343, -3)
@@ -288,12 +288,12 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM decs WHERE id = 2", [], decimal_format: :decimal)
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 2
-    assert Map.fetch!(row, "decimal") == Decimal.new(1, 95343, -3)
+    assert Map.fetch!(row, "a_decimal") == Decimal.new(1, 95343, -3)
 
     page = Xandra.execute!(conn, "SELECT * FROM decs WHERE id = 2", [], decimal_format: :tuple)
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 2
-    assert Map.fetch!(row, "decimal") == decimal_as_tuple
+    assert Map.fetch!(row, "a_decimal") == decimal_as_tuple
 
     # -5.0
     negative_decimal = Decimal.new("-5.0")
@@ -308,19 +308,19 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM decs WHERE id = 3", [], decimal_format: :decimal)
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 3
-    assert Map.fetch!(row, "decimal") == Decimal.new("-5.0")
-    assert row |> Map.fetch!("decimal") |> Decimal.negative?()
+    assert Map.fetch!(row, "a_decimal") == Decimal.new("-5.0")
+    assert row |> Map.fetch!("a_decimal") |> Decimal.negative?()
   end
 
   test "uuid/timeuuid types with format", %{conn: conn} do
     statement = """
-    CREATE TABLE uuids (id int PRIMARY KEY, uuid uuid, timeuuid timeuuid)
+    CREATE TABLE uuids (id int PRIMARY KEY, a_uuid uuid, a_timeuuid timeuuid)
     """
 
     Xandra.execute!(conn, statement)
 
     statement = """
-    INSERT INTO uuids (id, uuid, timeuuid) VALUES (?, ?, ?)
+    INSERT INTO uuids (id, a_uuid, a_timeuuid) VALUES (?, ?, ?)
     """
 
     uuid_as_binary = <<0, 182, 145, 128, 208, 225, 17, 226, 139, 139, 8, 0, 32, 12, 154, 102>>
@@ -338,8 +338,8 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM uuids WHERE id = 1", [], options)
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 1
-    assert Map.fetch!(row, "uuid") == uuid_as_binary
-    assert Map.fetch!(row, "timeuuid") == timeuuid_as_binary
+    assert Map.fetch!(row, "a_uuid") == uuid_as_binary
+    assert Map.fetch!(row, "a_timeuuid") == timeuuid_as_binary
 
     uuid_as_string = "fe2b4360-28c6-11e2-81c1-0800200c9a66"
     timeuuid_as_string = "fe2b4360-28c6-11e2-81c1-0800200c9a67"
@@ -356,8 +356,8 @@ defmodule DataTypesTest do
     page = Xandra.execute!(conn, "SELECT * FROM uuids WHERE id = 2", [], options)
     assert [row] = Enum.to_list(page)
     assert Map.fetch!(row, "id") == 2
-    assert Map.fetch!(row, "uuid") == uuid_as_string
-    assert Map.fetch!(row, "timeuuid") == timeuuid_as_string
+    assert Map.fetch!(row, "a_uuid") == uuid_as_string
+    assert Map.fetch!(row, "a_timeuuid") == timeuuid_as_string
   end
 
   test "collection datatypes", %{conn: conn} do

--- a/test/integration/errors_test.exs
+++ b/test/integration/errors_test.exs
@@ -3,7 +3,7 @@ defmodule ErrorsTest do
 
   alias Xandra.Error
 
-  test "each possible error", %{conn: conn} do
+  test "each possible error", %{conn: conn, is_cosmosdb: is_cosmosdb} do
     assert {:error, reason} = Xandra.execute(conn, "")
     assert %Error{reason: :invalid_syntax} = reason
 
@@ -15,7 +15,12 @@ defmodule ErrorsTest do
     assert %Error{reason: :already_exists} = reason
 
     assert {:error, reason} = Xandra.prepare(conn, "SELECT * FROM unknown")
-    assert %Error{reason: :invalid} = reason
+
+    if is_cosmosdb do
+      assert %Error{reason: :invalid_config} = reason
+    else
+      assert %Error{reason: :invalid} = reason
+    end
   end
 
   @tag :cassandra_specific

--- a/test/integration/not_set_test.exs
+++ b/test/integration/not_set_test.exs
@@ -33,7 +33,7 @@ defmodule NotSetTest do
 
     page = Xandra.execute!(conn, "SELECT id, name FROM cars")
 
-    assert Enum.to_list(page) == [
+    assert Enum.sort(page, &(&1["id"] <= &2["id"])) == [
              %{"id" => 1, "name" => "Tesla"},
              %{"id" => 2, "name" => "BMW"},
              %{"id" => 3, "name" => "T3"}
@@ -45,7 +45,7 @@ defmodule NotSetTest do
 
     page = Xandra.execute!(conn, "SELECT id, name FROM cars")
 
-    assert Enum.to_list(page) == [
+    assert Enum.sort(page, &(&1["id"] <= &2["id"])) == [
              %{"id" => 1, "name" => "Mercedes"},
              %{"id" => 2, "name" => nil},
              %{"id" => 3, "name" => "T3"}

--- a/test/integration/paging_test.exs
+++ b/test/integration/paging_test.exs
@@ -11,7 +11,7 @@ defmodule PagingTest do
     Xandra.execute!(conn, statement)
 
     statement = """
-    BEGIN BATCH
+    BEGIN UNLOGGED BATCH
     INSERT INTO alphabet (lang, letter) VALUES ('en', 'Aa');
     INSERT INTO alphabet (lang, letter) VALUES ('en', 'Bb');
     INSERT INTO alphabet (lang, letter) VALUES ('en', 'Cc');

--- a/test/integration/prepared_test.exs
+++ b/test/integration/prepared_test.exs
@@ -65,7 +65,7 @@ defmodule PreparedTest do
     prepared = Xandra.prepare!(conn, "SELECT * FROM users")
 
     assert inspect(prepared) ==
-             ~s(#Xandra.Prepared<[statement: "SELECT * FROM users", tracing_id: nil]>)
+             ~s(#Xandra.Prepared<[statement: "SELECT * FROM users", tracing_id: nil, custom_payload: nil]>)
   end
 
   test "missing named params raise an error", %{conn: conn} do

--- a/test/integration/results_test.exs
+++ b/test/integration/results_test.exs
@@ -42,7 +42,7 @@ defmodule ResultsTest do
     %Xandra.Page{} = page = Xandra.execute!(conn, "SELECT * FROM users")
 
     assert inspect(page) ==
-             ~s(#Xandra.Page<[rows: [%{"name" => "Jeff"}], tracing_id: nil, more_pages?: false]>)
+             ~s(#Xandra.Page<[rows: [%{"name" => "Jeff"}], tracing_id: nil, custom_payload: nil, more_pages?: false]>)
   end
 
   describe "SCHEMA_CHANGE updates since native protocol v4" do

--- a/test/integration/tracing_test.exs
+++ b/test/integration/tracing_test.exs
@@ -3,6 +3,8 @@ defmodule TracingTest do
 
   alias Xandra.Batch
 
+  @moduletag :cosmosdb_unsupported
+
   setup_all %{keyspace: keyspace, start_options: start_options} do
     {:ok, conn} = Xandra.start_link(start_options)
     Xandra.execute!(conn, "USE #{keyspace}")

--- a/test/integration/warning_test.exs
+++ b/test/integration/warning_test.exs
@@ -3,6 +3,9 @@ defmodule WarningTest do
 
   alias Xandra.Batch
 
+  # Technically, this is supported by Cosmos DB, but this test cannot trigger a warning like this.
+  @moduletag :cosmosdb_unsupported
+
   setup_all %{keyspace: keyspace, start_options: start_options} do
     {:ok, conn} = Xandra.start_link(start_options)
     Xandra.execute!(conn, "USE #{keyspace}")

--- a/test/windows/cosmosdb-download-install.ps1
+++ b/test/windows/cosmosdb-download-install.ps1
@@ -1,0 +1,31 @@
+
+Function Get-RedirectedUrl {
+  Param (
+    [Parameter(Mandatory=$true)]
+    [String]$URL
+  )
+
+  $request = [System.Net.WebRequest]::Create($url)
+  $request.AllowAutoRedirect=$false
+  $response = $request.GetResponse()
+  If ($response.StatusCode -eq "Found" -or $response.StatusCode -eq "MovedPermanently") {
+    $response.GetResponseHeader("Location")
+  }
+  Else {
+    $URL
+  }
+}
+
+Write-Host "Downloading Cosmos DB Emulator..."
+$url = Get-RedirectedUrl "https://aka.ms/cosmosdb-emulator"
+Invoke-WebRequest -Uri $url -OutFile "cosmosdb-emulator-install.msi"
+
+Write-Host "Installing..."
+$MSIArguments = @(
+  "/i"
+  "cosmosdb-emulator-install.msi"
+  "/quiet"
+  "/qn"
+  "/norestart"
+)
+Start-Process "msiexec.exe" -ArgumentList $MSIArguments -Wait

--- a/test/windows/cosmosdb-start-wait.ps1
+++ b/test/windows/cosmosdb-start-wait.ps1
@@ -1,12 +1,21 @@
 
 Push-Location -Path "$Env:Programfiles\Azure Cosmos DB Emulator"
 
-Start-Process -FilePath ".\Microsoft.Azure.Cosmos.Emulator.exe" -Args "/EnableCassandraEndpoint","/EnableRateLimiting","/NoExplorer"
+Start-Process -FilePath ".\Microsoft.Azure.Cosmos.Emulator.exe" -Args "/EnableCassandraEndpoint","/EnableRateLimiting","/NoExplorer","/NoUI"
 
 Write-Host "Waiting for Cosmos DB to start..."
-do {
+$lastExitCode = 0
+Do {
   Start-Sleep -Seconds 1
   $process = (Start-Process -FilePath ".\Microsoft.Azure.Cosmos.Emulator.exe" -Args "/GetStatus" -PassThru -Wait)
-} while($process.ExitCode -ne 2)
+  If ($process.ExitCode -ne $lastExitCode) {
+    Write-Host "GetStatus code =" $process.ExitCode
+    $lastExitCode = $process.ExitCode
+  }
+  If ($lastExitCode -eq 3 -or $lastExitCode -lt 0) {
+    Pop-Location
+    Exit 1
+  }
+} While ($process.ExitCode -ne 2)
 
 Pop-Location

--- a/test/windows/cosmosdb-start-wait.ps1
+++ b/test/windows/cosmosdb-start-wait.ps1
@@ -1,0 +1,12 @@
+
+Push-Location -Path "$Env:Programfiles\Azure Cosmos DB Emulator"
+
+Start-Process -FilePath ".\Microsoft.Azure.Cosmos.Emulator.exe" -Args "/EnableCassandraEndpoint","/EnableRateLimiting","/NoExplorer"
+
+Write-Host "Waiting for Cosmos DB to start..."
+do {
+  Start-Sleep -Seconds 1
+  $process = (Start-Process -FilePath ".\Microsoft.Azure.Cosmos.Emulator.exe" -Args "/GetStatus" -PassThru -Wait)
+} while($process.ExitCode -ne 2)
+
+Pop-Location

--- a/test/windows/cosmosdb-stop-wait.ps1
+++ b/test/windows/cosmosdb-stop-wait.ps1
@@ -1,0 +1,12 @@
+
+Push-Location -Path "$Env:Programfiles\Azure Cosmos DB Emulator"
+
+Start-Process -FilePath ".\Microsoft.Azure.Cosmos.Emulator.exe" -Args "/Shutdown"
+
+Write-Host "Waiting for Cosmos DB to stop..."
+do {
+  Start-Sleep -Seconds 1
+  $process = (Start-Process -FilePath ".\Microsoft.Azure.Cosmos.Emulator.exe" -Args "/GetStatus" -PassThru -Wait)
+} while($process.ExitCode -ne 3)
+
+Pop-Location


### PR DESCRIPTION
Receiving custom payload is tested to work against Azure Cosmos DB when using protocol v4. Sending could not be tested but should be working as well.

I did my best to also document the new feature, but I don't have a unit test ready for you.

Let me know if you have any questions or if I made a mistake.