### PR TITLE
Support custom load balance policy

### DIFF
--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -228,7 +228,7 @@ defmodule Xandra.Cluster.ControlConnection do
     end
   end
 
-  defp maybe_fetch_node_info(_state, event), do: event
+  defp maybe_enrich_event(_state, event), do: event
 
   defp decode_frame(buffer, protocol_module) do
     header_length = Frame.header_length()

--- a/lib/xandra/cluster/node.ex
+++ b/lib/xandra/cluster/node.ex
@@ -2,7 +2,7 @@ defmodule Xandra.Cluster.Node do
   @enforce_keys [
     :address,
     :data_center,
-    :rack,
+    :rack
   ]
 
   defstruct @enforce_keys

--- a/lib/xandra/cluster/node.ex
+++ b/lib/xandra/cluster/node.ex
@@ -1,0 +1,23 @@
+defmodule Xandra.Cluster.Node do
+  @enforce_keys [
+    :address,
+    :data_center,
+    :rack,
+  ]
+
+  defstruct @enforce_keys
+
+  def new(node_info) do
+    %{
+      "rpc_address" => address,
+      "rack" => rack,
+      "data_center" => data_center
+    } = node_info
+
+    %__MODULE__{
+      address: address,
+      rack: rack,
+      data_center: data_center
+    }
+  end
+end

--- a/lib/xandra/cluster/topology_change.ex
+++ b/lib/xandra/cluster/topology_change.ex
@@ -1,5 +1,5 @@
 defmodule Xandra.Cluster.TopologyChange do
   @moduledoc false
 
-  defstruct [:effect, :address, :port]
+  defstruct [:effect, :address, :port, :node]
 end


### PR DESCRIPTION
I'd like to propose a proof of concept of supporting custom load balancing policy. This would also make future implementation of token-aware load balancing possible too.

In a nutshell, the policy behavior callback would take in the nodes, and the query being executed and return the selected node to execute the query with.