### PR TITLE
Expose `start_link_opts_schema`

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -341,6 +341,11 @@ defmodule Xandra do
   @start_link_opts_schema NimbleOptions.new!(start_link_opts_schema)
   @start_link_opts_keys Keyword.keys(start_link_opts_schema)
 
+  @doc false
+  def start_link_opts_schema do
+    @start_link_opts_schema
+  end
+
   @doc """
   Starts a new pool of connections to Cassandra.
 


### PR DESCRIPTION
As a maintainer of a library that uses Xandra and NimbleOptions and passes options through to `Xandra.start_link/` I am interested in documenting the options directly inside my code. For this it would be helpful to be able to access the `start_link_opts_schema`.