### PR TITLE
Handle `new_page/1` for Batch queries

### DIFF
--- a/lib/xandra/protocol/v3.ex
+++ b/lib/xandra/protocol/v3.ex
@@ -643,9 +643,8 @@ defmodule Xandra.Protocol.V3 do
     %Xandra.SchemaChange{effect: effect, target: target, options: options, tracing_id: tracing_id}
   end
 
-  # Since SELECT statements are not allowed in BATCH queries, there's no need to
-  # support %Batch{} in this function.
   defp new_page(%Simple{}), do: %Page{}
+  defp new_page(%Batch{}), do: %Page{}
   defp new_page(%Prepared{result_columns: result_columns}), do: %Page{columns: result_columns}
 
   defp rewrite_column_types(columns, options) do

--- a/lib/xandra/protocol/v4.ex
+++ b/lib/xandra/protocol/v4.ex
@@ -667,9 +667,8 @@ defmodule Xandra.Protocol.V4 do
     %Xandra.SchemaChange{effect: effect, target: target, options: options, tracing_id: tracing_id}
   end
 
-  # Since SELECT statements are not allowed in BATCH queries, there's no need to
-  # support %Batch{} in this function.
   defp new_page(%Simple{}), do: %Page{}
+  defp new_page(%Batch{}), do: %Page{}
   defp new_page(%Prepared{result_columns: result_columns}), do: %Page{columns: result_columns}
 
   defp rewrite_column_types(columns, options) do


### PR DESCRIPTION
If there is an statement with a lightweight transaction (e.g `IF NOT EXISTS`), then the returned result will be a page representing the status of that transaction(s).

Because of this, the `new_page/1` function in `v3` and `v4` protocol modules needs to also handle the Batch queries.

Also a small test case for this scenario is added to batch tests.