### PR TITLE
Use NimbleOptions internally for control conns

### DIFF
--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -607,13 +607,20 @@ defmodule Xandra.Cluster do
   defp control_conn_child_spec({address, port}, %__MODULE__{} = state) do
     %__MODULE__{
       autodiscovery: autodiscovery?,
-      pool_options: options,
+      pool_options: pool_options,
       control_conn_mod: control_conn_mod
     } = state
 
-    node_ref = make_ref()
-    start_args = [_cluster = self(), node_ref, address, port, options, autodiscovery?]
-    Supervisor.child_spec({control_conn_mod, start_args}, id: node_ref, restart: :transient)
+    opts = [
+      cluster: self(),
+      node_ref: make_ref(),
+      address: address,
+      port: port,
+      connection_options: pool_options,
+      autodiscovery: autodiscovery?
+    ]
+
+    Supervisor.child_spec({control_conn_mod, opts}, id: opts[:node_ref], restart: :transient)
   end
 
   defp start_pool(%__MODULE__{} = state, _node_ref, {ip, port} = peername) do

--- a/test/integration/cluster_test.exs
+++ b/test/integration/cluster_test.exs
@@ -8,14 +8,12 @@ defmodule Xandra.ClusterTest do
   defmodule PoolMock do
     use GenServer
 
-    def start_link(opts) do
-      GenServer.start_link(__MODULE__, opts)
-    end
+    def start_link(opts), do: GenServer.start_link(__MODULE__, Map.new(opts))
 
     @impl true
     def init(opts) do
       {test_pid, test_ref} = :persistent_term.get(:clustering_test_info)
-      send(test_pid, {test_ref, __MODULE__, :init_called, Map.new(opts)})
+      send(test_pid, {test_ref, __MODULE__, :init_called, opts})
       {:ok, {test_pid, test_ref}}
     end
   end
@@ -23,13 +21,7 @@ defmodule Xandra.ClusterTest do
   defmodule ControlConnectionMock do
     use GenServer
 
-    def child_spec([_cluster, _node_ref, _address, _port, _options, _autodiscovery?] = args) do
-      %{id: __MODULE__, type: :worker, start: {__MODULE__, :start_link, args}}
-    end
-
-    def start_link(cluster, node_ref, address, port, options, autodiscovery?) do
-      GenServer.start_link(__MODULE__, Map.new(binding()))
-    end
+    def start_link(opts), do: GenServer.start_link(__MODULE__, Map.new(opts))
 
     @impl true
     def init(args) do

--- a/test/xandra/cluster/control_connection_test.exs
+++ b/test/xandra/cluster/control_connection_test.exs
@@ -15,16 +15,16 @@ defmodule Xandra.Cluster.ControlConnectionTest do
 
     node_ref = make_ref()
 
-    args = [
-      _cluster = mirror,
-      node_ref,
-      'localhost',
-      9042,
-      _options = [protocol_module: @protocol_module],
-      _autodiscovery? = true
+    opts = [
+      cluster: mirror,
+      node_ref: node_ref,
+      address: 'localhost',
+      port: 9042,
+      connection_options: [protocol_module: @protocol_module],
+      autodiscovery: true
     ]
 
-    assert {:ok, _ctrl_conn} = start_supervised({ControlConnection, args})
+    assert {:ok, _ctrl_conn} = start_supervised({ControlConnection, opts})
 
     assert_receive {^mirror_ref, {:"$gen_cast", {:activate, _ref, {{127, 0, 0, 1}, 9042}}}}
     assert_receive {^mirror_ref, {:"$gen_cast", {:discovered_peers, [], "127.0.0.1:9042"}}}
@@ -37,21 +37,16 @@ defmodule Xandra.Cluster.ControlConnectionTest do
 
     node_ref = make_ref()
 
-    args = [
-      _cluster = mirror,
-      node_ref,
-      'localhost',
-      9042,
-      _options = [protocol_module: @protocol_module],
-      _autodiscovery? = false
+    opts = [
+      cluster: mirror,
+      node_ref: node_ref,
+      address: 'localhost',
+      port: 9042,
+      connection_options: [protocol_module: @protocol_module],
+      autodiscovery: false
     ]
 
-    assert {:ok, ctrl_conn} =
-             start_supervised(%{
-               id: ControlConnection,
-               start: {ControlConnection, :start_link, args},
-               type: :worker
-             })
+    assert {:ok, ctrl_conn} = start_supervised({ControlConnection, opts})
 
     assert_receive {^mirror_ref, {:"$gen_cast", {:activate, _ref, {{127, 0, 0, 1}, 9042}}}}
 


### PR DESCRIPTION
No changes in any public API, just a refactor to make it harder to
screw up when starting a new control connection.