### PR TITLE
Remove :address/:port in Xandra.start_link/1

### DIFF
--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -25,8 +25,7 @@ defmodule Xandra.Connection do
 
   @impl true
   def connect(options) when is_list(options) do
-    address = Keyword.fetch!(options, :address)
-    port = Keyword.fetch!(options, :port)
+    {address, port} = Keyword.fetch!(options, :node)
     prepared_cache = Keyword.fetch!(options, :prepared_cache)
     compressor = Keyword.get(options, :compressor)
     default_consistency = Keyword.fetch!(options, :default_consistency)

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -27,13 +27,21 @@ defmodule Xandra.OptionsValidators do
   end
 
   @doc false
-  def validate_ip({a, b, c, d} = ip)
-      when is_integer(a) and is_integer(b) and is_integer(c) and is_integer(d) do
-    {:ok, ip}
+  def validate_node(value) when is_binary(value) do
+    case String.split(value, ":", parts: 2) do
+      [address, port] ->
+        case Integer.parse(port) do
+          {port, ""} -> {:ok, {String.to_charlist(address), port}}
+          _ -> {:error, "invalid node: #{inspect(value)}"}
+        end
+
+      [address] ->
+        {:ok, {String.to_charlist(address), 9042}}
+    end
   end
 
-  def validate_ip(other) do
-    {:error, "invalid IP address: #{inspect(other)}"}
+  def validate_node(other) do
+    {:error, "expected node to be a string or a {ip, port} tuple, got: #{inspect(other)}"}
   end
 
   @doc false

--- a/test/xandra_test.exs
+++ b/test/xandra_test.exs
@@ -2,22 +2,12 @@ defmodule XandraTest do
   use ExUnit.Case, async: true
 
   test "options validation in Xandra.start_link/1" do
-    message = "invalid item \"foo:bar\" in the :nodes option"
-
-    assert_raise ArgumentError, message, fn ->
+    assert_raise NimbleOptions.ValidationError, ~r{invalid node: "foo:bar"}, fn ->
       Xandra.start_link(nodes: ["foo:bar"])
     end
 
-    message = "multi-node use requires Xandra.Cluster instead of Xandra"
-
-    assert_raise ArgumentError, message, fn ->
+    assert_raise ArgumentError, ~r{cannot use multiple nodes in the :nodes option}, fn ->
       Xandra.start_link(nodes: ["foo", "bar"])
-    end
-
-    message = "invalid item \"bar:baz\" in the :nodes option"
-
-    assert_raise ArgumentError, message, fn ->
-      Xandra.start_link(nodes: ["bar:baz"])
     end
   end
 end


### PR DESCRIPTION
Closes #215.

This option was internal and only used by Xandra.Cluster. This commit
simplifies the logic so that the cluster uses the public API, too.