### PR TITLE
Add testing mix alias to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
           mix deps.compile
 
       - name: Run tests
-        run: mix test.native_protocols --only-protocols %{{ matrix.cassandra_native_protocols }} --trace
+        run: mix test.native_protocols --only-protocols ${{ matrix.cassandra_native_protocols }} --trace
 
       - name: Dump Docker logs on failure
         uses: jwalton/gh-docker-logs@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
 
   test:
     name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}, C* ${{ matrix.cassandra_version }}, Native protocols ${{ matrix.cassandra_native_protocols }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -139,7 +139,7 @@ jobs:
 
   test_clustering:
     name: Test C* Clustering (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}, C* ${{ matrix.cassandra_version }}, Native protocol ${{ matrix.cassandra_native_protocol }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,8 +70,76 @@ jobs:
         run: mix dialyzer
 
   test:
-    name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}, C* ${{ matrix.cassandra_version }}, Native protocol ${{ matrix.cassandra_native_protocol }})
-    runs-on: ubuntu-20.04
+    name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}, C* ${{ matrix.cassandra_version }}, Native protocols ${{ matrix.cassandra_native_protocols }})
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - otp: "24.2"
+            elixir: "1.13"
+            cassandra_version: "4"
+            cassandra_native_protocols: "v4,v5"
+            lint: true
+          - otp: "24.2"
+            elixir: "1.13"
+            cassandra_version: "3"
+            cassandra_native_protocols: "v3,v4"
+          - otp: "24.2"
+            elixir: "1.13"
+            cassandra_version: "2.2"
+            cassandra_native_protocols: "v3"
+          # Oldest supported Elixir/OTP matrix.
+          # Elixir 1.9 supports OTP 20, but telemetry doesn't, so we force
+          # OTP 21 here.
+          - otp: "21.3"
+            elixir: "1.9"
+            cassandra_version: "3"
+            cassandra_native_protocols: "v3"
+    env:
+      CASSANDRA_VERSION: ${{ matrix.cassandra_version }}
+      NIMBLELZ4_FORCE_BUILD: ${{ matrix.elixir == '1.9' && 'true' }}
+
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v2
+
+      - name: Start Docker and wait for it to be up
+        run: |
+          docker-compose up --detach --build
+          ./test/docker/health-check-services.sh
+
+      - name: Install OTP and Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-otp${{ matrix.otp }}-elixir${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+
+      - name: Install and compile dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          mix deps.get --only test
+          mix deps.compile
+
+      - name: Run tests
+        run: mix test.native_protocols --only-protocols %{{ matrix.cassandra_native_protocols }} --trace
+
+      - name: Dump Docker logs on failure
+        uses: jwalton/gh-docker-logs@v1
+        if: failure()
+
+  test_clustering:
+    name: Test C* Clustering (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}, C* ${{ matrix.cassandra_version }}, Native protocol ${{ matrix.cassandra_native_protocol }})
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -138,9 +206,6 @@ jobs:
         run: |
           mix deps.get --only test
           mix deps.compile
-
-      - name: Run tests
-        run: mix test --trace
 
       - name: Run clustering end-to-end tests
         run: mix test.clustering

--- a/test/support/mix_tasks/test.native_protocols.ex
+++ b/test/support/mix_tasks/test.native_protocols.ex
@@ -7,14 +7,9 @@ defmodule Mix.Tasks.Test.NativeProtocols do
 
   @impl true
   def run(args) do
-    {opts, test_args} = OptionParser.parse!(args, strict: @switches)
-
-    test_args =
-      if "--no-color" in test_args do
-        ["test"] ++ test_args
-      else
-        ["test", "--color"] ++ test_args
-      end
+    {opts_and_test_opts, test_args} = OptionParser.parse!(args, switches: @switches)
+    {opts, test_opts} = Keyword.split(opts_and_test_opts, Keyword.keys(@switches))
+    test_args = ["test"] ++ test_args ++ OptionParser.to_argv(test_opts)
 
     protocol_versions =
       case Keyword.fetch(opts, :only_protocols) do

--- a/test/support/mix_tasks/test.native_protocols.ex
+++ b/test/support/mix_tasks/test.native_protocols.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Test.NativeProtocols do
     {_result, exit_status} =
       if protocol_version == :auto do
         Mix.shell().info([:cyan, "Testing with negotiated native protocol version", :reset])
-        System.cmd("mix", test_args, stderr_to_stdout: false, into: IO.stream())
+        System.cmd("mix", test_args, stderr_to_stdout: false, into: IO.stream(:stdio, :line))
       else
         Mix.shell().info([
           :cyan,
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Test.NativeProtocols do
         System.cmd("mix", test_args,
           stderr_to_stdout: false,
           env: %{"CASSANDRA_NATIVE_PROTOCOL" => Atom.to_string(protocol_version)},
-          into: IO.stream()
+          into: IO.stream(:stdio, :line)
         )
       end
 


### PR DESCRIPTION
Wanted to help finish off this issue https://github.com/lexhide/xandra/issues/244. I made a couple changes:

1. Changed the CI so it uses this alias to run the unit tests.
2. Changed the alias function so that it can pass arguments down to `mix test`. i.e. you can run `mix test.native_protocols --color --only tag_name` and the resulting `mix test` command will run with `--color` and `--only tag_name` switches.

I separated out the clustering test suite into a new job because I didn't work out the best way to create a new alias for it yet. But I can leave this PR open until I get it done and add it here, if you prefer that.

