### PR TITLE
Add basic support for custom payloads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
             cassandra_native_protocol: "v4"
           - otp: "24.2"
             elixir: "1.13"
-            scylla_version: "2.0.0"
+            scylla_version: "2.3.1"
             cassandra_native_protocol: "v3"
 
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,10 +158,6 @@ jobs:
         include:
           - otp: "24.2"
             elixir: "1.13"
-            scylla_version: "5.0.0"
-            cassandra_native_protocol: "v4"
-          - otp: "24.2"
-            elixir: "1.13"
             scylla_version: "4.6.3"
             cassandra_native_protocol: "v4"
           - otp: "24.2"

--- a/docker-compose.scylladb.yml
+++ b/docker-compose.scylladb.yml
@@ -9,6 +9,9 @@ services:
         SCYLLA_VERSION: ${SCYLLA_VERSION:-2.3.1}
     ports:
       - "9042:9042"
+    command:
+      - "--smp"
+      - "2"
     healthcheck:
       test: [ "CMD-SHELL", "nodetool -h ::FFFF:127.0.0.1 status" ]
       interval: 20s
@@ -28,6 +31,9 @@ services:
         AUTHENTICATION: "true"
     ports:
       - "9043:9042"
+    command:
+      - "--smp"
+      - "2"
     healthcheck:
       test: [ "CMD-SHELL", "nodetool -h ::FFFF:127.0.0.1 status" ]
       interval: 20s

--- a/docker-compose.scylladb.yml
+++ b/docker-compose.scylladb.yml
@@ -11,7 +11,7 @@ services:
       - "9042:9042"
     command:
       - "--smp"
-      - "2"
+      - "1"
     healthcheck:
       test: [ "CMD-SHELL", "nodetool -h ::FFFF:127.0.0.1 status" ]
       interval: 20s
@@ -33,7 +33,7 @@ services:
       - "9043:9042"
     command:
       - "--smp"
-      - "2"
+      - "1"
     healthcheck:
       test: [ "CMD-SHELL", "nodetool -h ::FFFF:127.0.0.1 status" ]
       interval: 20s

--- a/docker-compose.scylladb.yml
+++ b/docker-compose.scylladb.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./test/docker
       dockerfile: scylladb.dockerfile
+      args:
+        SCYLLA_VERSION: ${SCYLLA_VERSION:-2.3.1}
     ports:
       - "9042:9042"
     healthcheck:
@@ -22,6 +24,7 @@ services:
       context: ./test/docker
       dockerfile: scylladb.dockerfile
       args:
+        SCYLLA_VERSION: ${SCYLLA_VERSION:-2.3.1}
         AUTHENTICATION: "true"
     ports:
       - "9043:9042"

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -214,6 +214,7 @@ defmodule Xandra do
   @type error :: Error.t() | ConnectionError.t()
   @type result :: Xandra.Void.t() | Page.t() | Xandra.SetKeyspace.t() | Xandra.SchemaChange.t()
   @type conn :: DBConnection.conn()
+  @type custom_payload :: %{optional(String.t()) => binary()}
 
   @type xandra_start_option ::
           {:nodes, [String.t()]}
@@ -544,6 +545,12 @@ defmodule Xandra do
       given query and sets the `tracing_id` field in the returned prepared
       query. See the "Tracing" option in `execute/4`.
       """
+    ],
+    custom_payload: [
+      type: {:custom, Xandra.OptionsValidators, :validate_custom_payload, []},
+      doc: """
+      TODO
+      """
     ]
   ]
 
@@ -801,6 +808,12 @@ defmodule Xandra do
       Turn on tracing for the preparation of the
       given query and sets the `tracing_id` field in the returned prepared
       query. See the "Tracing" option in `execute/4`.
+      """
+    ],
+    custom_payload: [
+      type: {:custom, Xandra.OptionsValidators, :validate_custom_payload, []},
+      doc: """
+      TODO
       """
     ],
     date_format: [

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -194,6 +194,24 @@ defmodule Xandra do
   Xandra connections log a few events like disconnections or connection failures.
   Logs contain the `:xandra_address` and `:xandra_port` metadata that you can
   choose to log if desired.
+
+  ## Custom payloads
+
+  The Cassandra native protocol supports exchanging **custom payloads** between
+  server and client. A custom payload is a map of string keys to binary values
+  (`t:custom_payload/0`).
+
+  To *send* custom payloads to the server, you can pass the `:custom_payload`
+  option to functions such as `prepare/3` and `execute/4`.
+
+  If the server sends a custom payload in a response (`t:result/0`), you'll find
+  it in the `:custom_payload` field of the corresponding struct (such as
+  `Xandra.Page`, `Xandra.Void`, and so on).
+
+  By default, Cassandra itself ignores custom payloads sent to the server. Other
+  implementations built on top of the Cassandra native protocol might use
+  custom payloads to provide implementation-specific functionality. One such
+  example is Azure [Cosmos DB](https://azure.microsoft.com/en-us/services/cosmos-db/).
   """
 
   alias __MODULE__.{
@@ -214,6 +232,13 @@ defmodule Xandra do
   @type error :: Error.t() | ConnectionError.t()
   @type result :: Xandra.Void.t() | Page.t() | Xandra.SetKeyspace.t() | Xandra.SchemaChange.t()
   @type conn :: DBConnection.conn()
+
+  @typedoc """
+  Custom payload that Xandra can exchange with the server.
+
+  See the ["Custom payloads"](#module-custom-payloads) section in the
+  module documentation.
+  """
   @type custom_payload :: %{optional(String.t()) => binary()}
 
   @type xandra_start_option ::
@@ -549,7 +574,10 @@ defmodule Xandra do
     custom_payload: [
       type: {:custom, Xandra.OptionsValidators, :validate_custom_payload, []},
       doc: """
-      TODO
+      A custom payload to send to the Cassandra server alongside the request. Only
+      supported in `QUERY`, `PREPARE`, `EXECUTE`, and `BATCH` requests. The custom
+      payload must be of type `t:custom_payload/0`. See the
+      ["Custom payloads"](#module-custom-payloads) section in the module documentation.
       """
     ]
   ]
@@ -813,7 +841,10 @@ defmodule Xandra do
     custom_payload: [
       type: {:custom, Xandra.OptionsValidators, :validate_custom_payload, []},
       doc: """
-      TODO
+      A custom payload to send to the Cassandra server alongside the request. Only
+      supported in `QUERY`, `PREPARE`, `EXECUTE`, and `BATCH` requests. The custom
+      payload must be of type `t:custom_payload/0`. See the
+      ["Custom payloads"](#module-custom-payloads) section in the module documentation.
       """
     ],
     date_format: [

--- a/lib/xandra/batch.ex
+++ b/lib/xandra/batch.ex
@@ -14,7 +14,13 @@ defmodule Xandra.Batch do
 
   @enforce_keys [:type]
   defstruct @enforce_keys ++
-              [queries: [], default_consistency: nil, protocol_module: nil, compressor: nil]
+              [
+                queries: [],
+                default_consistency: nil,
+                protocol_module: nil,
+                compressor: nil,
+                custom_payload: nil
+              ]
 
   @type type :: :logged | :unlogged | :counter
 
@@ -24,7 +30,8 @@ defmodule Xandra.Batch do
           queries: [Simple.t() | Prepared.t()],
           default_consistency: atom() | nil,
           protocol_module: module() | nil,
-          compressor: module() | nil
+          compressor: module() | nil,
+          custom_payload: Xandra.custom_payload() | nil
         }
 
   @type t() :: t(type)
@@ -107,7 +114,11 @@ defmodule Xandra.Batch do
     def encode(batch, _values = nil, options) do
       batch = %@for{batch | queries: Enum.reverse(batch.queries)}
 
-      Frame.new(:batch, tracing: options[:tracing], compressor: batch.compressor)
+      Frame.new(:batch,
+        tracing: options[:tracing],
+        compressor: batch.compressor,
+        custom_payload: batch.custom_payload
+      )
       |> batch.protocol_module.encode_request(batch, options)
       |> Frame.encode(batch.protocol_module)
     end

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -154,7 +154,8 @@ defmodule Xandra.Connection do
       | default_consistency: state.default_consistency,
         protocol_module: state.protocol_module,
         keyspace: state.current_keyspace,
-        compressor: compressor
+        compressor: compressor,
+        request_custom_payload: options[:custom_payload]
     }
 
     force? = Keyword.fetch!(options, :force)
@@ -166,7 +167,9 @@ defmodule Xandra.Connection do
 
       :error ->
         frame_options =
-          options |> Keyword.take([:tracing]) |> Keyword.put(:compressor, compressor)
+          options
+          |> Keyword.take([:tracing, :custom_payload])
+          |> Keyword.put(:compressor, compressor)
 
         payload =
           Frame.new(:prepare, frame_options)
@@ -201,7 +204,8 @@ defmodule Xandra.Connection do
       simple
       | default_consistency: state.default_consistency,
         protocol_module: state.protocol_module,
-        compressor: get_right_compressor(state, options[:compressor])
+        compressor: get_right_compressor(state, options[:compressor]),
+        custom_payload: options[:custom_payload]
     }
 
     {:ok, simple, state}
@@ -212,7 +216,8 @@ defmodule Xandra.Connection do
       batch
       | default_consistency: state.default_consistency,
         protocol_module: state.protocol_module,
-        compressor: get_right_compressor(state, options[:compressor])
+        compressor: get_right_compressor(state, options[:compressor]),
+        custom_payload: options[:custom_payload]
     }
 
     {:ok, batch, state}

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -2,7 +2,7 @@ defmodule Xandra.OptionsValidators do
   # Validator functions used by nimble_options schema definitions all throughout Xandra.
   @moduledoc false
 
-  @doc false
+  @spec validate_module(term(), String.t()) :: {:ok, module()} | {:error, String.t()}
   def validate_module(value, name) when is_binary(name) do
     cond do
       is_atom(value) and Code.ensure_loaded?(value) ->
@@ -16,7 +16,7 @@ defmodule Xandra.OptionsValidators do
     end
   end
 
-  @doc false
+  @spec validate_authentication(term()) :: {:ok, module()} | {:error, String.t()}
   def validate_authentication({module, keyword} = value)
       when is_atom(module) and is_list(keyword) do
     with {:ok, _module} <- validate_module(module, "authentication"), do: {:ok, value}
@@ -26,7 +26,7 @@ defmodule Xandra.OptionsValidators do
     {:error, "expected :authentication to be a {module, options} tuple, got: #{inspect(other)}"}
   end
 
-  @doc false
+  @spec validate_node(term()) :: {:ok, {charlist(), integer()}} | {:error, String.t()}
   def validate_node(value) when is_binary(value) do
     case String.split(value, ":", parts: 2) do
       [address, port] ->
@@ -44,12 +44,21 @@ defmodule Xandra.OptionsValidators do
     {:error, "expected node to be a string or a {ip, port} tuple, got: #{inspect(other)}"}
   end
 
-  @doc false
-  def validate_binary(value, key) do
+  @spec validate_binary(term(), atom()) :: {:ok, binary()} | {:error, String.t()}
+  def validate_binary(value, key) when is_atom(key) do
     if is_binary(value) do
       {:ok, value}
     else
       {:error, "expected #{inspect(key)} to be a binary, got: #{inspect(value)}"}
+    end
+  end
+
+  @spec validate_custom_payload(term()) :: {:ok, Xandra.custom_payload()} | {:error, String.t()}
+  def validate_custom_payload(term) do
+    if is_map(term) and Enum.all?(term, fn {key, val} -> is_binary(key) and is_binary(val) end) do
+      {:ok, term}
+    else
+      {:error, "expected custom payload to be a map of string to binary, got: #{inspect(term)}"}
     end
   end
 end

--- a/lib/xandra/page.ex
+++ b/lib/xandra/page.ex
@@ -33,7 +33,7 @@ defmodule Xandra.Page do
 
   """
 
-  defstruct [:content, :columns, :paging_state, :tracing_id]
+  defstruct [:content, :columns, :paging_state, :tracing_id, :custom_payload]
 
   @type paging_state :: binary | nil
 
@@ -41,7 +41,8 @@ defmodule Xandra.Page do
           content: list,
           columns: nonempty_list,
           paging_state: paging_state,
-          tracing_id: binary | nil
+          tracing_id: binary | nil,
+          custom_payload: Xandra.custom_payload() | nil
         }
 
   defimpl Enumerable do

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -7,7 +7,10 @@ defmodule Xandra.Prepared do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
-    * TODO
+    * `:response_custom_payload` - the *custom payload* sent by the server, if present.
+      If the server doesn't send a custom payload, this field is `nil`. Otherwise,
+      it's of type `t:Xandra.custom_payload/0`. See the "Custom payloads" section
+      in the documentation for the `Xandra` module.
 
   All other fields are documented in `t:t/0` to avoid Dialyzer warnings,
   but are not meant to be used by users.

--- a/lib/xandra/prepared.ex
+++ b/lib/xandra/prepared.ex
@@ -7,6 +7,8 @@ defmodule Xandra.Prepared do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * TODO
+
   All other fields are documented in `t:t/0` to avoid Dialyzer warnings,
   but are not meant to be used by users.
   """
@@ -21,6 +23,8 @@ defmodule Xandra.Prepared do
     :protocol_module,
     :compressor,
     :tracing_id,
+    :request_custom_payload,
+    :response_custom_payload,
     :keyspace,
     :result_metadata_id
   ]
@@ -35,6 +39,8 @@ defmodule Xandra.Prepared do
           protocol_module: module | nil,
           compressor: module | nil,
           tracing_id: binary | nil,
+          request_custom_payload: Xandra.custom_payload() | nil,
+          response_custom_payload: Xandra.custom_payload() | nil,
           keyspace: binary | nil,
           result_metadata_id: binary | nil
         }
@@ -67,7 +73,11 @@ defmodule Xandra.Prepared do
     end
 
     def encode(prepared, values, options) when is_list(values) do
-      Frame.new(:execute, tracing: options[:tracing], compressor: prepared.compressor)
+      Frame.new(:execute,
+        tracing: options[:tracing],
+        compressor: prepared.compressor,
+        custom_payload: prepared.request_custom_payload
+      )
       |> prepared.protocol_module.encode_request(%{prepared | values: values}, options)
       |> Frame.encode(prepared.protocol_module)
     end

--- a/lib/xandra/protocol/protocol.ex
+++ b/lib/xandra/protocol/protocol.ex
@@ -25,6 +25,13 @@ defmodule Xandra.Protocol do
   def frame_protocol_format(Xandra.Protocol.V4), do: :v4_or_less
   def frame_protocol_format(Xandra.Protocol.V5), do: :v5_or_more
 
+  @spec supports_custom_payload?(module()) :: boolean()
+  def supports_custom_payload?(protocol_module)
+
+  def supports_custom_payload?(Xandra.Protocol.V3), do: false
+  def supports_custom_payload?(Xandra.Protocol.V4), do: true
+  def supports_custom_payload?(Xandra.Protocol.V5), do: true
+
   # Decodes a "string" as per
   # https://github.com/apache/cassandra/blob/dcf3d58c4b22b8b69e8505b170829172ea3c4f5c/doc/native_protocol_v5.spec#L361
   # > "A [short] n, followed by n bytes representing an UTF-8 string."

--- a/lib/xandra/protocol/v4.ex
+++ b/lib/xandra/protocol/v4.ex
@@ -55,37 +55,52 @@ defmodule Xandra.Protocol.V4 do
   end
 
   def encode_request(%Frame{kind: :query} = frame, %Simple{} = query, options) do
-    %{statement: statement, values: values} = query
+    %Simple{statement: statement, values: values, custom_payload: custom_payload} = query
 
     body = [
+      encode_custom_payload(custom_payload),
       <<byte_size(statement)::32>>,
       statement,
       encode_params([], values, options, query.default_consistency, _skip_metadata? = false)
     ]
 
-    %{frame | body: body}
+    %Frame{frame | body: body}
   end
 
   def encode_request(%Frame{kind: :prepare} = frame, %Prepared{} = prepared, _options) do
-    %{statement: statement} = prepared
-    %{frame | body: [<<byte_size(statement)::32>>, statement]}
+    %Prepared{statement: statement, request_custom_payload: custom_payload} = prepared
+
+    body = [
+      encode_custom_payload(custom_payload),
+      <<byte_size(statement)::32>>,
+      statement
+    ]
+
+    %Frame{frame | body: body}
   end
 
   def encode_request(%Frame{kind: :execute} = frame, %Prepared{} = prepared, options) do
-    %{id: id, bound_columns: columns, values: values} = prepared
+    %Prepared{
+      id: id,
+      bound_columns: columns,
+      values: values,
+      request_custom_payload: custom_payload
+    } = prepared
+
     skip_metadata? = prepared.result_columns != nil
 
     body = [
+      encode_custom_payload(custom_payload),
       <<byte_size(id)::16>>,
       id,
       encode_params(columns, values, options, prepared.default_consistency, skip_metadata?)
     ]
 
-    %{frame | body: body}
+    %Frame{frame | body: body}
   end
 
   def encode_request(%Frame{kind: :batch} = frame, %Batch{} = batch, options) do
-    %{queries: queries, type: type} = batch
+    %Batch{queries: queries, type: type, custom_payload: custom_payload} = batch
 
     consistency = Keyword.get(options, :consistency, batch.default_consistency)
     serial_consistency = Keyword.get(options, :serial_consistency)
@@ -99,6 +114,7 @@ defmodule Xandra.Protocol.V4 do
     encoded_queries = [<<length(queries)::16>>] ++ Enum.map(queries, &encode_query_in_batch/1)
 
     body = [
+      encode_custom_payload(custom_payload),
       encode_batch_type(type),
       encoded_queries,
       encode_consistency_level(consistency),
@@ -107,7 +123,20 @@ defmodule Xandra.Protocol.V4 do
       if(timestamp, do: <<timestamp::64>>, else: [])
     ]
 
-    %{frame | body: body}
+    %Frame{frame | body: body}
+  end
+
+  defp encode_custom_payload(nil) do
+    []
+  end
+
+  defp encode_custom_payload(custom_payload) when is_map(custom_payload) do
+    key_value_pairs =
+      for {key, value} <- custom_payload do
+        [<<byte_size(key)::16>>, key, <<byte_size(value)::32>>, value]
+      end
+
+    [<<map_size(custom_payload)::16>> | key_value_pairs]
   end
 
   defp encode_batch_type(:logged), do: 0
@@ -542,6 +571,7 @@ defmodule Xandra.Protocol.V4 do
           kind: :result,
           body: body,
           tracing: tracing?,
+          custom_payload: custom_payload?,
           atom_keys?: atom_keys?,
           warning: warning?
         },
@@ -551,12 +581,14 @@ defmodule Xandra.Protocol.V4 do
       when kind in [Simple, Prepared, Batch] do
     {body, tracing_id} = decode_tracing_id(body, tracing?)
     {warnings, body} = Proto.decode_warnings(body, warning?)
+    {custom_payload, body} = decode_custom_payload(body, custom_payload?)
 
     result =
       decode_result_response(
         body,
         query,
         tracing_id,
+        custom_payload,
         Keyword.put(options, :atom_keys?, atom_keys?)
       )
 
@@ -580,24 +612,61 @@ defmodule Xandra.Protocol.V4 do
     {body, tracing_id}
   end
 
+  defp decode_custom_payload(body, false) do
+    {nil, body}
+  end
+
+  defp decode_custom_payload(body, true) do
+    decode_bytes_map(body)
+  end
+
   # Void
-  defp decode_result_response(<<0x0001::32-signed>>, _query, tracing_id, _options) do
-    %Xandra.Void{tracing_id: tracing_id}
+  defp decode_result_response(
+         <<0x0001::32-signed>>,
+         _query,
+         tracing_id,
+         custom_payload,
+         _options
+       ) do
+    %Xandra.Void{tracing_id: tracing_id, custom_payload: custom_payload}
   end
 
   # Page
-  defp decode_result_response(<<0x0002::32-signed, buffer::bits>>, query, tracing_id, options) do
+  defp decode_result_response(
+         <<0x0002::32-signed, buffer::bits>>,
+         query,
+         tracing_id,
+         custom_payload,
+         options
+       ) do
     %Page{} = page = new_page(query)
     {page, buffer} = decode_metadata(buffer, page, Keyword.fetch!(options, :atom_keys?))
     columns = rewrite_column_types(page.columns, options)
-    %Page{page | content: decode_page_content(buffer, columns), tracing_id: tracing_id}
+
+    %Page{
+      page
+      | content: decode_page_content(buffer, columns),
+        tracing_id: tracing_id,
+        custom_payload: custom_payload
+    }
   end
 
   # SetKeyspace
-  defp decode_result_response(<<0x0003::32-signed, buffer::bits>>, _query, tracing_id, _options) do
+  defp decode_result_response(
+         <<0x0003::32-signed, buffer::bits>>,
+         _query,
+         tracing_id,
+         custom_payload,
+         _options
+       ) do
     decode_string(keyspace <- buffer)
     <<>> = buffer
-    %Xandra.SetKeyspace{keyspace: keyspace, tracing_id: tracing_id}
+
+    %Xandra.SetKeyspace{
+      keyspace: keyspace,
+      tracing_id: tracing_id,
+      custom_payload: custom_payload
+    }
   end
 
   # Prepared
@@ -605,6 +674,7 @@ defmodule Xandra.Protocol.V4 do
          <<0x0004::32-signed, buffer::bits>>,
          %Prepared{} = prepared,
          tracing_id,
+         custom_payload,
          options
        ) do
     atom_keys? = Keyword.fetch!(options, :atom_keys?)
@@ -617,16 +687,30 @@ defmodule Xandra.Protocol.V4 do
       | id: id,
         bound_columns: bound_columns,
         result_columns: result_columns,
-        tracing_id: tracing_id
+        tracing_id: tracing_id,
+        response_custom_payload: custom_payload
     }
   end
 
   # SchemaChange
-  defp decode_result_response(<<0x0005::32-signed, buffer::bits>>, _query, tracing_id, _options) do
+  defp decode_result_response(
+         <<0x0005::32-signed, buffer::bits>>,
+         _query,
+         tracing_id,
+         custom_payload,
+         _options
+       ) do
     decode_string(effect <- buffer)
     decode_string(target <- buffer)
     options = decode_change_options(buffer, target)
-    %Xandra.SchemaChange{effect: effect, target: target, options: options, tracing_id: tracing_id}
+
+    %Xandra.SchemaChange{
+      effect: effect,
+      target: target,
+      options: options,
+      tracing_id: tracing_id,
+      custom_payload: custom_payload
+    }
   end
 
   defp new_page(%Simple{}), do: %Page{}
@@ -1103,5 +1187,22 @@ defmodule Xandra.Protocol.V4 do
     decode_string(key <- buffer)
     {value, buffer} = Proto.decode_string_list(buffer)
     decode_string_multimap(buffer, count - 1, [{key, value} | acc])
+  end
+
+  # A [short] n, followed by n pair <k><v> where <k> is a [string] and <v> is a [bytes].
+  defp decode_bytes_map(<<count::16, buffer::bits>>) do
+    decode_bytes_map(buffer, count, [])
+  end
+
+  defp decode_bytes_map(<<buffer::bits>>, 0, acc) do
+    {Map.new(acc), buffer}
+  end
+
+  defp decode_bytes_map(<<buffer::bits>>, count, acc) do
+    decode_string(key <- buffer)
+
+    decode_value(value <- buffer, :blob) do
+      decode_bytes_map(buffer, count - 1, [{key, value} | acc])
+    end
   end
 end

--- a/lib/xandra/schema_change.ex
+++ b/lib/xandra/schema_change.ex
@@ -21,7 +21,10 @@ defmodule Xandra.SchemaChange do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
-    * TODO
+    * `:custom_payload` - the *custom payload* sent by the server, if present.
+      If the server doesn't send a custom payload, this field is `nil`. Otherwise,
+      it's of type `t:Xandra.custom_payload/0`. See the "Custom payloads" section
+      in the documentation for the `Xandra` module.
 
   """
 

--- a/lib/xandra/schema_change.ex
+++ b/lib/xandra/schema_change.ex
@@ -21,14 +21,17 @@ defmodule Xandra.SchemaChange do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * TODO
+
   """
 
-  defstruct [:effect, :target, :options, :tracing_id]
+  defstruct [:effect, :target, :options, :tracing_id, :custom_payload]
 
   @type t :: %__MODULE__{
           effect: String.t(),
           target: String.t(),
           options: map,
-          tracing_id: binary | nil
+          tracing_id: binary | nil,
+          custom_payload: Xandra.custom_payload() | nil
         }
 end

--- a/lib/xandra/set_keyspace.ex
+++ b/lib/xandra/set_keyspace.ex
@@ -10,7 +10,10 @@ defmodule Xandra.SetKeyspace do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
-    * TODO
+    * `:custom_payload` - the *custom payload* sent by the server, if present.
+      If the server doesn't send a custom payload, this field is `nil`. Otherwise,
+      it's of type `t:Xandra.custom_payload/0`. See the "Custom payloads" section
+      in the documentation for the `Xandra` module.
 
   """
 

--- a/lib/xandra/set_keyspace.ex
+++ b/lib/xandra/set_keyspace.ex
@@ -10,12 +10,15 @@ defmodule Xandra.SetKeyspace do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * TODO
+
   """
 
-  defstruct [:keyspace, :tracing_id]
+  defstruct [:keyspace, :tracing_id, :custom_payload]
 
   @type t :: %__MODULE__{
           keyspace: String.t(),
-          tracing_id: binary() | nil
+          tracing_id: binary() | nil,
+          custom_payload: Xandra.custom_payload() | nil
         }
 end

--- a/lib/xandra/simple.ex
+++ b/lib/xandra/simple.ex
@@ -3,14 +3,22 @@ defmodule Xandra.Simple do
   A data structure used internally to represent simple queries.
   """
 
-  defstruct [:statement, :values, :default_consistency, :protocol_module, :compressor]
+  defstruct [
+    :statement,
+    :values,
+    :default_consistency,
+    :protocol_module,
+    :compressor,
+    :custom_payload
+  ]
 
   @type t :: %__MODULE__{
           statement: Xandra.statement(),
           values: Xandra.values() | nil,
           default_consistency: atom() | nil,
           protocol_module: module() | nil,
-          compressor: module() | nil
+          compressor: module() | nil,
+          custom_payload: Xandra.custom_payload() | nil
         }
 
   defimpl DBConnection.Query do
@@ -22,7 +30,11 @@ defmodule Xandra.Simple do
 
     # "options" are the options given to DBConnection.execute/4.
     def encode(%@for{} = query, values, options) do
-      Frame.new(:query, tracing: options[:tracing], compressor: query.compressor)
+      Frame.new(:query,
+        tracing: options[:tracing],
+        compressor: query.compressor,
+        custom_payload: query.custom_payload
+      )
       |> query.protocol_module.encode_request(%@for{query | values: values}, options)
       |> Frame.encode(query.protocol_module)
     end

--- a/lib/xandra/void.ex
+++ b/lib/xandra/void.ex
@@ -10,9 +10,14 @@ defmodule Xandra.Void do
     * `:tracing_id` - the tracing ID (as a UUID binary) if tracing was enabled,
       or `nil` if no tracing was enabled. See the "Tracing" section in `Xandra.execute/4`.
 
+    * TODO
+
   """
 
-  defstruct [:tracing_id]
+  defstruct [:tracing_id, :custom_payload]
 
-  @type t :: %__MODULE__{tracing_id: binary | nil}
+  @type t :: %__MODULE__{
+          tracing_id: binary | nil,
+          custom_payload: Xandra.custom_payload() | nil
+        }
 end

--- a/test/docker/health-check-services.sh
+++ b/test/docker/health-check-services.sh
@@ -1,18 +1,27 @@
 #!/bin/bash
 
 # $SECONDS contains the number of seconds elapsed since starting the script.
-END_SECONDS=$((SECONDS+120))
+MAX_SECONDS=120
+END_SECONDS=$((SECONDS+MAX_SECONDS))
 
 for name in $(docker ps --format '{{.Names}}'); do
-  while [[ "$SECONDS" -lt "$END_SECONDS" ]]; do
-    STATUS=$(docker inspect --format "{{json .State.Health.Status }}" "$name")
+  HEALTHY=false
 
-    if [[ $STATUS == "\"healthy\"" ]]; then
-      echo "Docker $name is up and running"
+  while [[ "$SECONDS" -lt "$END_SECONDS" ]]; do
+    STATUS="$(docker inspect --format "{{json .State.Health.Status }}" "$name")"
+
+    if [[ "$STATUS" == '"healthy"' ]]; then
+      echo "Docker container '$name' is up and running"
+      HEALTHY=true
       break
     fi
 
-    >&2 echo "Docker $name is unavailable, waiting to start...";
+    >&2 echo "Docker container '$name' is unavailable, waiting to start...";
     sleep 3;
   done
+
+  if [[ "$HEALTHY" == false ]]; then
+    >&2 echo "Docker container '$name' failed to start after $MAX_SECONDS seconds"
+    exit 1
+  fi
 done

--- a/test/integration/custom_payload_test.exs
+++ b/test/integration/custom_payload_test.exs
@@ -1,6 +1,8 @@
 defmodule CustomPayloadTest do
   use XandraTest.IntegrationCase, async: true
 
+  @moduletag :cassandra_specific
+
   @example_custom_payload %{"some_key" => <<1, 2, 3>>}
 
   test "sending a custom payload when executing a simple query", %{conn: conn} do

--- a/test/integration/custom_payload_test.exs
+++ b/test/integration/custom_payload_test.exs
@@ -1,0 +1,52 @@
+defmodule CustomPayloadTest do
+  use XandraTest.IntegrationCase, async: true
+
+  @example_custom_payload %{"some_key" => <<1, 2, 3>>}
+
+  test "sending a custom payload when executing a simple query", %{conn: conn} do
+    assert {:ok, %Xandra.Page{} = response} =
+             Xandra.execute(conn, "SELECT * FROM system.local", _params = [],
+               custom_payload: @example_custom_payload
+             )
+
+    assert is_nil(response.custom_payload)
+  end
+
+  test "sending a custom payload when preparing a query", %{conn: conn} do
+    assert {:ok, %Xandra.Prepared{} = prepared} =
+             Xandra.prepare(conn, "SELECT * FROM system.local",
+               custom_payload: @example_custom_payload
+             )
+
+    assert prepared.request_custom_payload == @example_custom_payload
+    assert is_nil(prepared.response_custom_payload)
+  end
+
+  test "sending a custom payload when preparing a query and executing a query", %{conn: conn} do
+    # Send the custom payload when preparing the query.
+    assert {:ok, %Xandra.Prepared{} = prepared} =
+             Xandra.prepare(conn, "SELECT * FROM system.local",
+               custom_payload: @example_custom_payload
+             )
+
+    # Send the custom payload when executing the prepared query.
+    assert {:ok, %Xandra.Page{} = response} =
+             Xandra.execute(conn, prepared, [], custom_payload: @example_custom_payload)
+
+    assert is_nil(response.custom_payload)
+  end
+
+  test "sending a custom payload when executing a batch query", %{conn: conn, keyspace: keyspace} do
+    Xandra.execute!(conn, "CREATE TABLE #{keyspace}.users (id int, name text, PRIMARY KEY (id))")
+
+    batch =
+      Xandra.Batch.new()
+      |> Xandra.Batch.add("INSERT INTO users (id, name) VALUES (1, 'Joe')")
+      |> Xandra.Batch.add("INSERT INTO users (id, name) VALUES (1, 'Jane')")
+
+    assert {:ok, %Xandra.Void{} = void_response} =
+             Xandra.execute(conn, batch, custom_payload: @example_custom_payload)
+
+    assert is_nil(void_response.custom_payload)
+  end
+end


### PR DESCRIPTION
Supersedes https://github.com/lexhide/xandra/pull/185.

Closes #256.

This PR doesn't have any end-to-end testing since neither C* nor ScyllaDB support any built-in custom payload handling.