### PR TITLE
Start actually using :default_consistency

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -761,11 +761,12 @@ defmodule Xandra do
            :local_serial,
            :local_one
          ]},
-      default: :one,
       doc: """
       Specifies the consistency level for the given
       query. See the Cassandra documentation for more information on consistency
-      levels. The value of this option can be one of:
+      levels. If not present, defaults to the value of the `:default_consistency` option
+      used when starting the connection (see `start_link/1`).
+      The value of this option can be one of:
         * `:one`
         * `:two`
         * `:three`

--- a/test/docker/cassandra.dockerfile
+++ b/test/docker/cassandra.dockerfile
@@ -6,6 +6,7 @@ ARG AUTHENTICATION=false
 
 # Enable user-defined functions.
 RUN sed -i -e "s/\(enable_user_defined_functions: \)false/\1true/" /etc/cassandra/cassandra.yaml
+RUN sed -i -e "s/\(user_defined_functions_enabled: \)false/\1true/" /etc/cassandra/cassandra.yaml
 
 RUN if [ "$AUTHENTICATION" = true ]; then \
   sed -i -e "s/\(authenticator: \)AllowAllAuthenticator/\1PasswordAuthenticator/" /etc/cassandra/cassandra.yaml; \

--- a/test/integration/generic_test.exs
+++ b/test/integration/generic_test.exs
@@ -16,4 +16,13 @@ defmodule GenericTest do
              %{"code" => 1, "name" => "Meg"}
            ]
   end
+
+  # Regression for https://github.com/lexhide/xandra/issues/266
+  # This test doesn't test much for now, it's sort of a smoke test. Once we'll have
+  # generic telemetry events for queries, we can change this test to assert on the telemetry
+  # event.
+  test ":default_consistency option when starting", %{keyspace: keyspace} do
+    assert {:ok, test_conn} = start_supervised({Xandra, default_consistency: :three})
+    Xandra.execute!(test_conn, "USE #{keyspace}")
+  end
 end


### PR DESCRIPTION
Closes #266.

There was a bug preventing the use of the `:default_consistency` option,
since we were setting `:consistency` to `:one` as a default, never
actually falling back to `:default_consistency`. With this commit,
`:consistency` defaults to not being present instead.