### PR TITLE
Use a single control connection per cluster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,10 +90,8 @@ jobs:
             cassandra_version: "2.2"
             cassandra_native_protocols: "v3"
           # Oldest supported Elixir/OTP matrix.
-          # Elixir 1.9 supports OTP 20, but telemetry doesn't, so we force
-          # OTP 21 here.
           - otp: "21.3"
-            elixir: "1.9"
+            elixir: "1.10"
             cassandra_version: "3"
             cassandra_native_protocols: "v3"
     env:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :logger, :console,
+  format: "[$level] $metadata $message\n",
+  metadata: [:peer]

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -329,11 +329,18 @@ defmodule Xandra.Cluster.ControlConnection do
   defp inet_mod(:ssl), do: :ssl
 
   defp peername_to_string({host_or_ip, port}) do
-    if :inet.is_ip_address(host_or_ip) do
+    if ip_address?(host_or_ip) do
       "#{:inet.ntoa(host_or_ip)}:#{port}"
     else
       "#{host_or_ip}:#{port}"
     end
+  end
+
+  # TODO: remove the conditional once we depend on OTP 25+.
+  if function_exported?(:inet, :is_ip_address, 1) do
+    defp ip_address?(term), do: :inet.is_ip_address(term)
+  else
+    defp ip_address?(term), do: is_tuple(term)
   end
 
   defp recv_frame(transport, socket, protocol_format) do

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -66,9 +66,13 @@ defmodule Xandra.Cluster.ControlConnection do
     contact_points =
       options
       |> Keyword.fetch!(:contact_points)
-      |> Enum.map(fn contact_point ->
-        {:ok, node} = Xandra.OptionsValidators.validate_node(contact_point)
-        node
+      |> Enum.map(fn
+        {host, port} ->
+          {host, port}
+
+        contact_point ->
+          {:ok, node} = Xandra.OptionsValidators.validate_node(contact_point)
+          node
       end)
 
     data = %__MODULE__{

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -16,28 +16,34 @@ defmodule Xandra.Cluster.ControlConnection do
   # weak "type checking" (some people might get angry at this).
   @opts_schema NimbleOptions.new!(
                  cluster: [type: :pid, required: true],
-                 node_ref: [type: :reference, required: true],
-                 address: [type: :any, required: true],
-                 port: [type: {:in, 0..65355}, required: true],
+                 contact_points: [type: :any, required: true],
                  connection_options: [type: :keyword_list, required: true],
-                 autodiscovery: [type: :boolean, required: true]
+                 autodiscovered_nodes_port: [type: :non_neg_integer, required: true]
                )
 
   defstruct [
+    # The PID of the parent cluster.
     :cluster,
-    :node_ref,
-    :address,
-    :port,
+
+    # A list of {host, port} tuples. This is a mix of the seed nodes provided by the user
+    # as well as the nodes discovered throughout the lifetime of the control connection.
+    :peers,
+
+    # The transport and its options, used to connect to the provided nodes.
     :transport,
     :transport_options,
-    :socket,
+
+    # The options to use to connect to the nodes.
     :options,
-    :autodiscovery,
-    :protocol_module,
-    :peername,
-    new: true,
+
+    # Data buffer.
     buffer: <<>>
   ]
+
+  defmodule ConnectedNode do
+    @moduledoc false
+    defstruct [:socket, :protocol_module, :ip, :port]
+  end
 
   # Need to manually define child_spec/1 because :gen_statem doesn't provide any utilities
   # around that.
@@ -54,20 +60,23 @@ defmodule Xandra.Cluster.ControlConnection do
 
     transport = if connection_options[:encryption], do: :ssl, else: :gen_tcp
 
-    transport_options =
-      connection_options
-      |> Keyword.get(:transport_options, [])
-      |> Keyword.merge(@forced_transport_options)
+    {transport_options, connection_options} =
+      Keyword.pop(connection_options, :transport_options, [])
+
+    contact_points =
+      options
+      |> Keyword.fetch!(:contact_points)
+      |> Enum.map(fn contact_point ->
+        {:ok, node} = Xandra.OptionsValidators.validate_node(contact_point)
+        node
+      end)
 
     data = %__MODULE__{
       cluster: Keyword.fetch!(options, :cluster),
-      node_ref: Keyword.fetch!(options, :node_ref),
-      address: Keyword.fetch!(options, :address),
-      port: Keyword.fetch!(options, :port),
-      autodiscovery: Keyword.fetch!(options, :autodiscovery),
+      peers: contact_points,
       options: connection_options,
       transport: transport,
-      transport_options: transport_options
+      transport_options: Keyword.merge(transport_options, @forced_transport_options)
     }
 
     :gen_statem.start_link(__MODULE__, data, [])
@@ -75,252 +84,235 @@ defmodule Xandra.Cluster.ControlConnection do
 
   ## Callbacks
 
+  # The possible states are:
+  #
+  # * :disconnected - the control connection is not connected to any node
+  # * {:connected, %ConnectedNode{}} - the control connection is connected to the given node
+
   @impl :gen_statem
   def init(data) do
-    Logger.debug("Started control connection process (#{inspect(data.address)})")
+    Logger.debug("Started control connection process")
     {:ok, :disconnected, data, {:next_event, :internal, :connect}}
   end
 
   @impl :gen_statem
-  def callback_mode do
-    :state_functions
-  end
+  def callback_mode, do: :handle_event_function
 
   # Disconnected state
 
-  def disconnected(:internal, :connect, %__MODULE__{} = data) do
-    %__MODULE__{options: options, address: address, port: port, transport: transport} = data
+  @impl true
+  def handle_event(type, content, state, data)
 
-    # A nil :protocol_version means "negotiate". A non-nil one means "enforce".
-    protocol_version = Keyword.get(options, :protocol_version)
+  # Connecting is the hardest thing control connections do. The gist is this:
+  #
+  #   1. We try to connect to each node in :seed_peernames until one succeeds
+  #   2. We discover the peers for that node
+  #   3. We register to the events for that node
+  #   4. We send the discovered peers back to the cluster alongside the connected node
+  #   5. We move to the state {:connected, node}
+  def handle_event(:internal, :connect, :disconnected, %__MODULE__{} = data) do
+    case connect_to_first_available_node(data) do
+      {:ok, connected_node, peers} ->
+        peers = Enum.uniq([{connected_node.ip, connected_node.port} | peers])
+        send(data.cluster, {:discovered_peers, peers})
 
-    case transport.connect(address, port, data.transport_options, @default_timeout) do
-      {:ok, socket} ->
-        data = %__MODULE__{data | socket: socket}
+        data = %__MODULE__{data | peers: Enum.uniq(data.peers ++ peers)}
+        {:next_state, {:connected, connected_node}, data}
 
-        with {:ok, supported_options, protocol_module} <-
-               Utils.request_options(transport, socket, protocol_version),
-             Logger.debug("Supported options: #{inspect(supported_options)}"),
-             data = %__MODULE__{data | protocol_module: protocol_module},
-             :ok <-
-               startup_connection(transport, socket, supported_options, protocol_module, options),
-             {:ok, peers_or_nil} <-
-               maybe_discover_peers(data.autodiscovery, transport, socket, protocol_module),
-             :ok <- register_to_events(transport, socket, protocol_module),
-             :ok <- inet_mod(transport).setopts(socket, active: true) do
-          Logger.debug("Established control connection (protocol #{inspect(protocol_module)})")
-          {:ok, data} = report_active(data)
-
-          if not is_nil(peers_or_nil) do
-            report_peers(data, peers_or_nil)
-          end
-
-          {:next_state, :connected, data}
-        else
-          {:error, {:use_this_protocol_instead, _failed_protocol_version, protocol_version}} ->
-            :ok = transport.close(socket)
-            data = update_in(data.options, &Keyword.put(&1, :protocol_version, protocol_version))
-            {:keep_state, data, {:next_event, :internal, :connect}}
-
-          {:error, %Xandra.Error{} = error} ->
-            Logger.error(
-              "Failed to establish control connection because of Cassandra error: " <>
-                Exception.message(error)
-            )
-
-            {:stop, error}
-
-          {:error, %Xandra.ConnectionError{}} = error ->
-            {:connect, :reconnect, data} = disconnect(error, data)
-            timeout_action = {{:timeout, :reconnect}, @default_backoff, nil}
-            {:keep_state, data, timeout_action}
-        end
-
-      {:error, reason} ->
-        Logger.debug(
-          "Failed to connect to #{inspect(address)}:#{port}: #{:inet.format_error(reason)}"
-        )
-
-        timeout_action = {{:timeout, :reconnect}, @default_backoff, data}
-        {:keep_state_and_data, timeout_action}
+      :error ->
+        {:keep_state_and_data, {{:timeout, :reconnect}, @default_backoff, nil}}
     end
   end
 
   # TCP/SSL messages that we get when we're already in the "disconnected" state can
   # be safely ignored.
-  def disconnected(:info, {kind, socket, _reason}, %__MODULE__{socket: socket})
-      when kind in [:tcp_error, :ssl_error] do
+  def handle_event(:info, msg, :disconnected, %__MODULE__{})
+      when is_tuple(msg) and elem(msg, 0) in [:tcp_error, :ssl_error, :tcp_closed, :ssl_closed] do
     :keep_state_and_data
   end
 
-  # TCP/SSL messages that we get when we're already in the "disconnected" state can
-  # be safely ignored.
-  def disconnected(:info, {kind, socket}, %__MODULE__{socket: socket})
-      when kind in [:tcp_closed, :ssl_closed] do
-    :keep_state_and_data
-  end
-
-  def disconnected({:timeout, :reconnect}, _content, _data) do
+  # Trigger the reconnect event once the timer expires.
+  def handle_event({:timeout, :reconnect}, _content, :disconnected, _data) do
     {:keep_state_and_data, {:next_event, :internal, :connect}}
   end
 
   # Connected state
 
-  def connected(:info, {kind, socket, reason}, %__MODULE__{socket: socket} = data)
+  # If there's a socket error with the current node, we TODO.
+  def handle_event(
+        :info,
+        {kind, socket, reason},
+        {:connected, %ConnectedNode{socket: socket}},
+        %__MODULE__{} = data
+      )
       when kind in [:tcp_error, :ssl_error] do
-    Logger.debug("Socket error: #{inspect(reason)}")
-    {:connect, :reconnect, data} = disconnect({:error, reason}, data)
+    _ = data.transport.close(socket)
+    Logger.debug("Socket error: #{:inet.format_error(reason)}")
     {:next_state, :disconnected, data, {:next_event, :internal, :connect}}
   end
 
-  def connected(:info, {kind, socket}, %__MODULE__{socket: socket} = data)
+  # If the current node closes the socket, we TODO
+  def handle_event(
+        :info,
+        {kind, socket},
+        {:connected, %ConnectedNode{socket: socket}},
+        %__MODULE__{} = data
+      )
       when kind in [:tcp_closed, :ssl_closed] do
+    _ = data.transport.close(socket)
     Logger.debug("Socket closed")
-    data.transport.close(data.socket)
-    data = %__MODULE__{data | buffer: <<>>, socket: nil}
+    Logger.metadata(peer: nil)
+
+    data = %__MODULE__{data | buffer: <<>>}
     {:next_state, :disconnected, data, {:next_event, :internal, :connect}}
   end
 
-  def connected(:info, {kind, socket, bytes}, %__MODULE__{socket: socket} = data)
+  # New data.
+  def handle_event(
+        :info,
+        {kind, socket, bytes},
+        {:connected, %ConnectedNode{socket: socket} = connected_node},
+        %__MODULE__{} = data
+      )
       when kind in [:tcp, :ssl] do
     data = update_in(data.buffer, &(&1 <> bytes))
-    data = consume_new_data(data)
+    data = consume_new_data(data, connected_node)
     {:keep_state, data}
   end
 
   ## Helper functions
 
-  defp disconnect({:error, reason}, %__MODULE__{} = data) do
-    Logger.debug(
-      "Disconnecting from #{address_to_human_readable_source(data)} because of error: #{:inet.format_error(reason)}"
-    )
+  defp connect_to_first_available_node(%__MODULE__{} = data) do
+    Enum.each(data.peers, fn {_host_or_ip, _port} = peer ->
+      case connect_to_node(peer, data) do
+        {:ok, %ConnectedNode{ip: ip, port: port, protocol_module: proto_mod}, _peers} = return ->
+          Logger.metadata(peer: peername_to_string({ip, port}))
+          Logger.debug("Established control connection to node (protocol #{inspect(proto_mod)})")
+          throw(return)
 
-    _ = data.transport.close(data.socket)
-    {:connect, :reconnect, %__MODULE__{data | socket: nil, buffer: <<>>}}
+        {:error, reason} ->
+          Logger.warning(
+            "Error connecting to #{peername_to_string(peer)}: #{:inet.format_error(reason)}"
+          )
+      end
+    end)
+  catch
+    :throw, return -> return
   end
 
-  # A control connection that never came online just came online.
-  defp report_active(
-         %__MODULE__{new: true, cluster: cluster, node_ref: node_ref, socket: socket} = data
-       ) do
-    case inet_mod(data.transport).peername(socket) do
-      {:ok, {_ip, _port} = peername} ->
-        :ok = Cluster.activate(cluster, node_ref, peername)
-        data = %__MODULE__{data | new: false, peername: peername}
-        {:ok, data}
+  defp connect_to_node({address, port} = node, data) do
+    import Utils, only: [request_options: 3]
+    %__MODULE__{options: options, transport: transport} = data
+
+    # A nil :protocol_version means "negotiate". A non-nil one means "enforce".
+    proto_vsn = Keyword.get(options, :protocol_version)
+
+    Logger.metadata(peer: peername_to_string(node))
+    Logger.debug("Opening new connection")
+
+    case transport.connect(address, port, data.transport_options, @default_timeout) do
+      {:ok, socket} ->
+        with {:ok, supported_opts, proto_mod} <- request_options(transport, socket, proto_vsn),
+             Logger.debug("Supported options: #{inspect(supported_opts)}"),
+             connected_node = %ConnectedNode{socket: socket, protocol_module: proto_mod},
+             :ok <- startup_connection(data, connected_node, supported_opts),
+             {:ok, peers} <- discover_peers(data, connected_node),
+             :ok <- register_to_events(data, connected_node),
+             :ok <- inet_mod(transport).setopts(socket, active: true) do
+          {:ok, {ip, port}} = inet_mod(transport).peername(socket)
+          connected_node = %ConnectedNode{connected_node | ip: ip, port: port}
+          {:ok, connected_node, peers}
+        else
+          {:error, {:use_this_protocol_instead, _failed_protocol_version, proto_vsn}} ->
+            Logger.debug("Cassandra said to use protocol #{inspect(proto_vsn)}, reconnecting")
+            transport.close(socket)
+            data = update_in(data.options, &Keyword.put(&1, :protocol_version, proto_vsn))
+            connect_to_node(node, data)
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp report_active(%__MODULE__{new: false, cluster: cluster, peername: peername} = data) do
-    Xandra.Cluster.update(cluster, {:control_connection_established, peername})
-    {:ok, data}
-  end
+  # # A control connection that never came online just came online.
+  # defp report_active(
+  #        %__MODULE__{new: true, cluster: cluster, node_ref: node_ref, socket: socket} = data
+  #      ) do
+  #   case inet_mod(data.transport).peername(socket) do
+  #     {:ok, {_ip, _port} = peername} ->
+  #       :ok = Cluster.activate(cluster, node_ref, peername)
+  #       data = %__MODULE__{data | new: false, peername: peername}
+  #       {:ok, data}
+  #   end
+  # end
 
-  defp report_peers(state, peers) do
-    source = address_to_human_readable_source(state)
-    :ok = Xandra.Cluster.discovered_peers(state.cluster, peers, source)
-  end
+  # defp report_active(%__MODULE__{new: false, cluster: cluster, peername: peername} = data) do
+  #   Xandra.Cluster.update(cluster, {:control_connection_established, peername})
+  #   {:ok, data}
+  # end
 
-  defp startup_connection(transport, socket, supported_options, protocol_module, options) do
+  defp startup_connection(%__MODULE__{} = data, %ConnectedNode{} = node, supported_options) do
     %{"CQL_VERSION" => [cql_version | _]} = supported_options
-    requested_options = %{"CQL_VERSION" => cql_version}
-    Utils.startup_connection(transport, socket, requested_options, protocol_module, nil, options)
+
+    Utils.startup_connection(
+      data.transport,
+      node.socket,
+      _requested_options = %{"CQL_VERSION" => cql_version},
+      node.protocol_module,
+      _compressor = nil,
+      data.options
+    )
   end
 
-  defp register_to_events(transport, socket, protocol_module) do
+  defp register_to_events(%__MODULE__{} = data, %ConnectedNode{} = node) do
     payload =
       Frame.new(:register, _options = [])
-      |> protocol_module.encode_request(["STATUS_CHANGE", "TOPOLOGY_CHANGE"])
-      |> Frame.encode(protocol_module)
+      |> node.protocol_module.encode_request(["STATUS_CHANGE", "TOPOLOGY_CHANGE"])
+      |> Frame.encode(node.protocol_module)
 
-    protocol_format = Xandra.Protocol.frame_protocol_format(protocol_module)
+    protocol_format = Xandra.Protocol.frame_protocol_format(node.protocol_module)
 
-    with :ok <- transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <-
-           Utils.recv_frame(transport, socket, protocol_format, _compressor = nil) do
-      :ok = protocol_module.decode_response(frame)
+    with :ok <- data.transport.send(node.socket, payload),
+         {:ok, %Frame{} = frame} <- recv_frame(data.transport, node.socket, protocol_format) do
+      :ok = node.protocol_module.decode_response(frame)
     else
       {:error, reason} ->
         {:error, reason}
     end
   end
 
-  defp maybe_discover_peers(_autodiscovery? = false, _transport, _socket, _protocol_module) do
-    {:ok, _peers = nil}
-  end
+  # Discover the peers in the same data center as the node we're connected to.
+  defp discover_peers(%__MODULE__{} = data, %ConnectedNode{} = node) do
+    select_peers_query = "SELECT host_id, rpc_address, data_center FROM system.peers"
 
-  defp maybe_discover_peers(_autodiscovery? = true, transport, socket, protocol_module) do
-    # Discover the peers in the same data center as the node we're connected to.
-    with {:ok, local_info} <- fetch_node_local_info(transport, socket, protocol_module),
-         local_data_center = Map.fetch!(local_info, "data_center"),
-         {:ok, peers} <- discover_peers(transport, socket, protocol_module) do
+    with {:ok, local_node_info} <- query(data, node, "SELECT data_center FROM system.local"),
+         [%{"data_center" => local_data_center}] = local_node_info,
+         {:ok, peers} <- query(data, node, select_peers_query) do
       # We filter out the peers with null host_id because they seem to be nodes that are down or
       # decommissioned but not removed from the cluster. See
       # https://github.com/lexhide/xandra/pull/196 and
       # https://user.cassandra.apache.narkive.com/APRtj5hb/system-peers-and-decommissioned-nodes.
       peers =
-        for %{"host_id" => host_id, "data_center" => data_center, "rpc_address" => address} <-
-              peers,
+        for %{"host_id" => host_id, "data_center" => dc, "rpc_address" => address} <- peers,
             not is_nil(host_id),
-            data_center == local_data_center,
+            dc == local_data_center,
             do: address
 
       {:ok, peers}
     end
   end
 
-  defp fetch_node_local_info(transport, socket, protocol_module) do
-    query = %Simple{
-      statement: "SELECT data_center FROM system.local",
-      values: [],
-      default_consistency: :one
-    }
-
-    payload =
-      Frame.new(:query, _options = [])
-      |> protocol_module.encode_request(query)
-      |> Frame.encode(protocol_module)
-
-    protocol_format = Xandra.Protocol.frame_protocol_format(protocol_module)
-
-    with :ok <- transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <-
-           Utils.recv_frame(transport, socket, protocol_format, _compressor = nil) do
-      {%Xandra.Page{} = page, _warnings} = protocol_module.decode_response(frame, query)
-      [local_info] = Enum.to_list(page)
-      {:ok, local_info}
-    end
-  end
-
-  defp discover_peers(transport, socket, protocol_module) do
-    query = %Simple{
-      statement: "SELECT host_id, rpc_address, data_center FROM system.peers",
-      values: [],
-      default_consistency: :one
-    }
-
-    payload =
-      Frame.new(:query, _options = [])
-      |> protocol_module.encode_request(query)
-      |> Frame.encode(protocol_module)
-
-    protocol_format = Xandra.Protocol.frame_protocol_format(protocol_module)
-
-    with :ok <- transport.send(socket, payload),
-         {:ok, %Frame{} = frame} <-
-           Utils.recv_frame(transport, socket, protocol_format, _compressor = nil) do
-      {%Xandra.Page{} = page, _warnings} = protocol_module.decode_response(frame, query)
-      {:ok, Enum.to_list(page)}
-    end
-  end
-
-  defp consume_new_data(%__MODULE__{cluster: cluster} = data) do
+  defp consume_new_data(%__MODULE__{cluster: cluster} = data, %ConnectedNode{} = connected_node) do
     case decode_frame(data.buffer) do
       {frame, rest} ->
-        {change_event, _warnings} = data.protocol_module.decode_response(frame)
+        {change_event, _warnings} = connected_node.protocol_module.decode_response(frame)
         Logger.debug("Received event: #{inspect(change_event)}")
         :ok = Cluster.update(cluster, change_event)
-        consume_new_data(%__MODULE__{data | buffer: rest})
+        consume_new_data(%__MODULE__{data | buffer: rest}, connected_node)
 
       :error ->
         data
@@ -347,12 +339,32 @@ defmodule Xandra.Cluster.ControlConnection do
   defp inet_mod(:gen_tcp), do: :inet
   defp inet_mod(:ssl), do: :ssl
 
-  defp address_to_human_readable_source(%__MODULE__{peername: {ip, port}}),
-    do: "#{:inet.ntoa(ip)}:#{port}"
+  defp peername_to_string({host_or_ip, port}) do
+    if :inet.is_ip_address(host_or_ip) do
+      "#{:inet.ntoa(host_or_ip)}:#{port}"
+    else
+      "#{host_or_ip}:#{port}"
+    end
+  end
 
-  defp address_to_human_readable_source(%__MODULE__{address: {_, _, _, _} = address, port: port}),
-    do: "#{:inet.ntoa(address)}:#{port}"
+  defp recv_frame(transport, socket, protocol_format) do
+    Utils.recv_frame(transport, socket, protocol_format, _compressor = nil)
+  end
 
-  defp address_to_human_readable_source(%__MODULE__{address: address, port: port}),
-    do: "#{address}:#{port}"
+  defp query(%__MODULE__{} = data, %ConnectedNode{} = node, statement) do
+    query = %Simple{statement: statement, values: [], default_consistency: :one}
+
+    payload =
+      Frame.new(:query, _options = [])
+      |> node.protocol_module.encode_request(query)
+      |> Frame.encode(node.protocol_module)
+
+    protocol_format = Xandra.Protocol.frame_protocol_format(node.protocol_module)
+
+    with :ok <- data.transport.send(node.socket, payload),
+         {:ok, %Frame{} = frame} <- recv_frame(data.transport, node.socket, protocol_format) do
+      {%Xandra.Page{} = page, _warnings} = node.protocol_module.decode_response(frame, query)
+      {:ok, Enum.to_list(page)}
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -89,6 +89,7 @@ defmodule Xandra.Mixfile do
       {:stream_data, "~> 0.5.0", only: [:dev, :test]}
     ] ++
       if Version.match?(System.version(), "~> 1.11") do
+        # TODO: remove this conditional once we require Elixir 1.11+
         [{:nimble_lz4, "~> 0.1.2", only: [:dev, :test]}]
       else
         []

--- a/test/integration/cluster_test.exs
+++ b/test/integration/cluster_test.exs
@@ -51,14 +51,6 @@ defmodule Xandra.ClusterTest do
       end
     end
 
-    test "validates the :autodiscovery option" do
-      message = ~r/invalid value for :autodiscovery/
-
-      assert_raise NimbleOptions.ValidationError, message, fn ->
-        Xandra.Cluster.start_link(nodes: ["example.com:9042"], autodiscovery: "not a boolean")
-      end
-    end
-
     test "validates the :autodiscovered_nodes_port option" do
       message = ~r/invalid value for :autodiscovered_nodes_port option/
 
@@ -90,25 +82,17 @@ defmodule Xandra.ClusterTest do
   end
 
   describe "with controlled mock processes" do
-    test "starts one control connection per node for the given nodes", %{test_ref: test_ref} do
+    test "starts a single control connection", %{test_ref: test_ref} do
       opts = [
         xandra_module: PoolMock,
         control_connection_module: ControlConnectionMock,
         nodes: ["node1.example.com", "node2.example.com"]
       ]
 
-      cluster = start_supervised!({Xandra.Cluster, opts})
+      cluster = start_link_supervised!({Xandra.Cluster, opts})
 
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node1.example.com'} = args}
-
-      assert is_reference(args.node_ref)
-      assert args.cluster == cluster
-
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node2.example.com'} = args}
-
-      assert is_reference(args.node_ref)
+      assert_receive {^test_ref, ControlConnectionMock, :init_called, args}
+      assert args.contact_points == [{'node1.example.com', 9042}, {'node2.example.com', 9042}]
       assert args.cluster == cluster
     end
 
@@ -118,91 +102,57 @@ defmodule Xandra.ClusterTest do
       opts = [
         xandra_module: PoolMock,
         control_connection_module: ControlConnectionMock,
-        nodes: ["node1.example.com"],
-        autodiscovery: false
+        nodes: ["node1.example.com"]
       ]
 
-      cluster = start_supervised!({Xandra.Cluster, opts})
+      cluster = start_link_supervised!({Xandra.Cluster, opts})
 
       assert_receive {^test_ref, ControlConnectionMock, :init_called, control_conn_args}
-      assert control_conn_args[:address] == 'node1.example.com'
+      assert control_conn_args[:contact_points] == [{'node1.example.com', 9042}]
 
-      assert :ok = Xandra.Cluster.activate(cluster, control_conn_args[:node_ref], {address, port})
-
+      send(cluster, {:discovered_peers, [{address, port}]})
       assert_pool_started(test_ref, {address, port})
     end
 
-    test "starts one control connection per node including discovered nodes", %{
-      test_ref: test_ref
-    } do
+    test "starts one pool per node", %{test_ref: test_ref} do
       opts = [
         xandra_module: PoolMock,
         control_connection_module: ControlConnectionMock,
-        nodes: ["node1.example.com", "node2.example.com"],
-        autodiscovery: true
+        nodes: ["node1.example.com", "node2.example.com"]
       ]
 
-      cluster = start_supervised!({Xandra.Cluster, opts})
+      cluster = start_link_supervised!({Xandra.Cluster, opts})
 
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node1.example.com'} = args1}
+      assert_receive {^test_ref, ControlConnectionMock, :init_called, args}
+      assert args.contact_points == [{'node1.example.com', 9042}, {'node2.example.com', 9042}]
 
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node2.example.com'} = args2}
+      send(
+        cluster,
+        {:discovered_peers, [{{199, 0, 0, 1}, 9042}, {{199, 0, 0, 10}, 9042}]}
+      )
 
-      # Simulate the control connection going up and reporting peers right away.
-      assert :ok = Xandra.Cluster.activate(cluster, args1.node_ref, {{199, 0, 0, 1}, 9042})
-      assert :ok = Xandra.Cluster.discovered_peers(cluster, [{199, 0, 0, 10}], "199.0.0.1")
-
-      # Assert that the cluster starts a pool for the node going up.
+      # Assert that the cluster starts a pool for each discovered peer.
       assert_pool_started(test_ref, "199.0.0.1:9042")
-
-      # Assert that the cluster starts a control connection for the discovered peer.
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: {199, 0, 0, 10}, node_ref: discovered_node_ref}}
-
-      assert :ok = Xandra.Cluster.activate(cluster, discovered_node_ref, {{199, 0, 0, 10}, 9042})
       assert_pool_started(test_ref, "199.0.0.10:9042")
-
-      # Now some fun: simulate that the control connection for the second "seed" node goes up and
-      # reports two peers: a new one and a one that was already reported.
-      assert :ok = Xandra.Cluster.activate(cluster, args2.node_ref, {{199, 0, 0, 2}, 9042})
-
-      # Assert that the cluster starts a pool for the node going up.
-      assert_pool_started(test_ref, "199.0.0.2:9042")
-
-      assert :ok =
-               Xandra.Cluster.discovered_peers(
-                 cluster,
-                 [{199, 0, 0, 11}, {199, 0, 0, 10}],
-                 "199.0.0.2"
-               )
-
-      # Assert that the control connection goes up for the new peer.
-      assert_receive {^test_ref, ControlConnectionMock, :init_called, %{address: {199, 0, 0, 11}}}
-
-      # Make sure that the control connection does not go up for the already-discovered peer.
-      refute_receive {^test_ref, ControlConnectionMock, :init_called, _args}
     end
   end
 
   test "handles status change events", %{test_ref: test_ref} do
-    peername = {address, port} = {{199, 0, 0, 1}, 9042}
+    peername = {address, _port} = {{199, 0, 0, 1}, 9042}
 
     opts = [
       xandra_module: PoolMock,
       control_connection_module: ControlConnectionMock,
-      nodes: ["node1"],
-      autodiscovery: false
+      nodes: ["node1"]
     ]
 
-    cluster = start_supervised!({Xandra.Cluster, opts})
+    cluster = start_link_supervised!({Xandra.Cluster, opts})
 
-    assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                    %{address: 'node1', node_ref: ref}}
+    assert_receive {^test_ref, ControlConnectionMock, :init_called, _args}
 
-    assert :ok = Xandra.Cluster.activate(cluster, ref, {address, port})
+    send(cluster, {:discovered_peers, [peername]})
     assert_pool_started(test_ref, peername)
+
     %{pool_supervisor: pool_sup, pools: %{^peername => pool}} = :sys.get_state(cluster)
 
     assert [{^peername, ^pool, :worker, _}] = Supervisor.which_children(pool_sup)
@@ -211,21 +161,17 @@ defmodule Xandra.ClusterTest do
     pool_monitor_ref = Process.monitor(pool)
 
     # StatusChange DOWN:
-
-    assert :ok = Xandra.Cluster.update(cluster, %StatusChange{effect: "DOWN", address: address})
-
+    send(cluster, {:cluster_event, %StatusChange{effect: "DOWN", address: address}})
     assert_receive {:DOWN, ^pool_monitor_ref, _, _, _}
-
     assert [{^peername, :undefined, :worker, _}] = Supervisor.which_children(pool_sup)
 
     assert :sys.get_state(cluster).pools == %{}
 
     # StatusChange UP:
-
-    assert :ok = Xandra.Cluster.update(cluster, %StatusChange{effect: "UP", address: address})
+    send(cluster, {:cluster_event, %StatusChange{effect: "UP", address: address}})
 
     new_pool =
-      wait_for_passing(200, fn ->
+      wait_for_passing(500, fn ->
         assert [{^peername, pid, :worker, _}] = Supervisor.which_children(pool_sup)
         assert is_pid(pid)
         pid
@@ -241,61 +187,36 @@ defmodule Xandra.ClusterTest do
     opts = [
       xandra_module: PoolMock,
       control_connection_module: ControlConnectionMock,
-      nodes: ["node1"],
-      autodiscovery: true
+      nodes: ["node1"]
     ]
 
-    cluster = start_supervised!({Xandra.Cluster, opts})
+    cluster = start_link_supervised!({Xandra.Cluster, opts})
 
-    assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                    %{address: 'node1', node_ref: ref}}
+    assert_receive {^test_ref, ControlConnectionMock, :init_called, _args}
 
-    assert :ok = Xandra.Cluster.activate(cluster, ref, {address, port})
+    send(cluster, {:discovered_peers, [peername]})
     assert_pool_started(test_ref, peername)
 
     # TopologyChange NEW_NODE
 
-    assert :ok =
-             Xandra.Cluster.update(cluster, %TopologyChange{
-               effect: "NEW_NODE",
-               address: new_address
-             })
+    send(cluster, {:cluster_event, %TopologyChange{effect: "NEW_NODE", address: new_address}})
 
-    assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                    %{address: ^new_address, node_ref: new_ref}}
+    wait_for_passing(500, fn ->
+      assert_pool_started(test_ref, {new_address, port})
+    end)
 
-    assert :ok = Xandra.Cluster.activate(cluster, new_ref, {new_address, 9042})
-    assert_pool_started(test_ref, {new_address, port})
+    # TopologyChange REMOVED_NODE (removing the original node)
 
-    # TopologyChange REMOVED_NODE
-    # (removing the original node)
-
-    %{pools: %{^peername => pool}, control_conn_supervisor: control_conn_sup} =
-      :sys.get_state(cluster)
-
-    control_conn =
-      Enum.find_value(Supervisor.which_children(control_conn_sup), fn
-        {^ref, pid, _, _} -> pid
-        _other -> nil
-      end)
-
+    %{pools: %{^peername => pool}, control_connection: control_conn} = :sys.get_state(cluster)
     assert is_pid(control_conn)
 
     pool_monitor_ref = Process.monitor(pool)
-    control_conn_monitor_ref = Process.monitor(control_conn)
 
-    assert :ok =
-             Xandra.Cluster.update(cluster, %TopologyChange{
-               effect: "REMOVED_NODE",
-               address: address
-             })
-
+    send(cluster, {:cluster_event, %TopologyChange{effect: "REMOVED_NODE", address: address}})
     assert_receive {:DOWN, ^pool_monitor_ref, _, _, _}
-    assert_receive {:DOWN, ^control_conn_monitor_ref, _, _, _}
 
     wait_for_passing(500, fn ->
       assert [_] = Supervisor.which_children(:sys.get_state(cluster).pool_supervisor)
-      assert [_] = Supervisor.which_children(:sys.get_state(cluster).control_conn_supervisor)
     end)
   end
 
@@ -303,20 +224,18 @@ defmodule Xandra.ClusterTest do
     opts = [
       xandra_module: PoolMock,
       control_connection_module: ControlConnectionMock,
-      nodes: ["node1"],
-      autodiscovery: true
+      nodes: ["node1"]
     ]
 
-    cluster = start_supervised!({Xandra.Cluster, opts})
+    cluster = start_link_supervised!({Xandra.Cluster, opts})
 
     # TopologyChange MOVED_NODE
 
     assert capture_log(fn ->
-             assert :ok =
-                      Xandra.Cluster.update(cluster, %TopologyChange{
-                        effect: "MOVED_NODE",
-                        address: {192, 0, 0, 1}
-                      })
+             send(
+               cluster,
+               {:cluster_event, %TopologyChange{effect: "MOVED_NODE", address: {192, 0, 0, 1}}}
+             )
 
              # We have to fall back to sleeping here because we cannot use wait_for_passing/2: we
              # don't know when to stop capturing the log.
@@ -324,7 +243,7 @@ defmodule Xandra.ClusterTest do
            end) =~ "Ignored TOPOLOGY_CHANGE event"
   end
 
-  test "handles race conditions for node discovery", %{test_ref: test_ref} do
+  test "handles the same peers being re-reported", %{test_ref: test_ref} do
     # Sometimes, a seed control connection will start up, report active, and report peers before
     # other seed control connections had a chance to report active. This causes us to start
     # control connections to discovered nodes that might match with other seed nodes, effectively
@@ -334,88 +253,27 @@ defmodule Xandra.ClusterTest do
 
     seed1_ip = {192, 0, 0, 1}
     seed2_ip = {192, 0, 0, 2}
-    seed1_ip_charlist = :inet.ntoa(seed1_ip)
-    seed2_ip_charlist = :inet.ntoa(seed2_ip)
     port = 9042
 
     opts = [
       xandra_module: PoolMock,
       control_connection_module: ControlConnectionMock,
-      nodes: [to_string(seed1_ip_charlist), to_string(seed2_ip_charlist)],
-      autodiscovery: true
+      nodes: [to_string(:inet.ntoa(seed1_ip))]
     ]
 
     # Start the cluster.
-    cluster = start_supervised!({Xandra.Cluster, opts})
+    cluster = start_link_supervised!({Xandra.Cluster, opts})
 
-    # First, both control connections are started.
-
-    assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                    %{address: ^seed1_ip_charlist, node_ref: seed1_cc_ref}}
-
-    assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                    %{address: ^seed2_ip_charlist, node_ref: seed2_cc_ref}}
-
-    # Let's say only the first one activates (and its pool starts up too).
-    assert :ok = Xandra.Cluster.activate(cluster, seed1_cc_ref, {seed1_ip, port})
+    # First, the control connection is started and both pools as well.
+    assert_receive {^test_ref, ControlConnectionMock, :init_called, _args}
+    send(cluster, {:discovered_peers, [{seed1_ip, port}]})
     assert_pool_started(test_ref, {seed1_ip, port})
-
-    assert :sys.get_state(cluster).node_refs == [
-             {:node_ref, seed1_cc_ref, {seed1_ip, port}},
-             {:node_ref, seed2_cc_ref, nil}
-           ]
-
     assert Map.has_key?(:sys.get_state(cluster).pools, {seed1_ip, port})
 
-    # Okay cool, now let's have the first seed control connection report the second seed control
-    # connection as a peer. Mind = blown?
-    assert :ok =
-             Xandra.Cluster.discovered_peers(cluster, [seed2_ip], to_string(:inet.ntoa(seed1_ip)))
-
-    # Well, the control connection for seed2 hasn't reported active yet, so the cluster
-    # starts a new one.
-    assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                    %{address: ^seed2_ip, node_ref: seed2_peer_cc_ref}}
-
-    assert :sys.get_state(cluster).node_refs == [
-             {:node_ref, seed1_cc_ref, {seed1_ip, port}},
-             {:node_ref, seed2_cc_ref, nil},
-             {:node_ref, seed2_peer_cc_ref, nil}
-           ]
-
-    refute Map.has_key?(:sys.get_state(cluster).pools, {seed2_ip, port})
-
-    # Now the seed2 "peer" control connection reports as active (and we starts its pool).
-    assert :ok = Xandra.Cluster.activate(cluster, seed2_peer_cc_ref, {seed2_ip, port})
+    # Now simulate the control connection re-reporting different peers for some reason.
+    send(cluster, {:discovered_peers, [{seed1_ip, port}, {seed2_ip, port}]})
     assert_pool_started(test_ref, {seed2_ip, port})
-
-    # Ah, now the address <-> node_ref mapping should be updated correctly.
-    assert :sys.get_state(cluster).node_refs == [
-             {:node_ref, seed1_cc_ref, {seed1_ip, port}},
-             {:node_ref, seed2_cc_ref, nil},
-             {:node_ref, seed2_peer_cc_ref, {seed2_ip, port}}
-           ]
-
     assert Map.has_key?(:sys.get_state(cluster).pools, {seed2_ip, port})
-
-    # And now the grand finale: the original seed2 control connection reports active (what a slow
-    # connection...).
-    assert :ok = Xandra.Cluster.activate(cluster, seed2_cc_ref, {seed2_ip, port})
-
-    # Okay, first things first: we should not start a new pool.
-    refute_any_pool_started(test_ref)
-
-    # Second things second: the address <-> node_ref mapping should be Good™ and we should have
-    # removed the unnecessary control connection.
-    assert :sys.get_state(cluster).node_refs == [
-             {:node_ref, seed1_cc_ref, {seed1_ip, port}},
-             {:node_ref, seed2_peer_cc_ref, {seed2_ip, port}}
-           ]
-
-    cc_children = Supervisor.which_children(:sys.get_state(cluster).control_conn_supervisor)
-
-    assert Enum.sort(Enum.map(cc_children, fn {ref, _, _, _} -> ref end)) ==
-             Enum.sort([seed1_cc_ref, seed2_peer_cc_ref])
   end
 
   describe "checkout call" do
@@ -423,11 +281,10 @@ defmodule Xandra.ClusterTest do
       opts = [
         xandra_module: PoolMock,
         control_connection_module: ControlConnectionMock,
-        nodes: ["node1"],
-        autodiscovery: true
+        nodes: ["node1"]
       ]
 
-      cluster = start_supervised!({Xandra.Cluster, opts})
+      cluster = start_link_supervised!({Xandra.Cluster, opts})
 
       assert GenServer.call(cluster, :checkout) == {:error, :empty}
     end
@@ -437,22 +294,15 @@ defmodule Xandra.ClusterTest do
         xandra_module: PoolMock,
         control_connection_module: ControlConnectionMock,
         nodes: ["node1", "node2"],
-        autodiscovery: false,
         load_balancing: :random
       ]
 
-      cluster = start_supervised!({Xandra.Cluster, opts})
+      cluster = start_link_supervised!({Xandra.Cluster, opts})
 
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node1', node_ref: ref1}}
+      assert_receive {^test_ref, ControlConnectionMock, :init_called, _args}
 
-      assert :ok = Xandra.Cluster.activate(cluster, ref1, {{192, 0, 0, 1}, 9042})
+      send(cluster, {:discovered_peers, [{{192, 0, 0, 1}, 9042}, {{192, 0, 0, 2}, 9042}]})
       assert_pool_started(test_ref, "192.0.0.1:9042")
-
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node2', node_ref: ref2}}
-
-      assert :ok = Xandra.Cluster.activate(cluster, ref2, {{192, 0, 0, 2}, 9042})
       assert_pool_started(test_ref, "192.0.0.2:9042")
 
       pool_pids =
@@ -462,6 +312,8 @@ defmodule Xandra.ClusterTest do
           for {_address, pid} <- pools, do: pid
         end)
 
+      # If we check out enough times with load_balancing: :random, statistically it
+      # means we have to have a non-sorted list of pids.
       random_pids =
         for _ <- 1..50 do
           assert {:ok, pid} = GenServer.call(cluster, :checkout)
@@ -478,22 +330,15 @@ defmodule Xandra.ClusterTest do
         xandra_module: PoolMock,
         control_connection_module: ControlConnectionMock,
         nodes: ["node1", "node2"],
-        autodiscovery: false,
         load_balancing: :priority
       ]
 
-      cluster = start_supervised!({Xandra.Cluster, opts})
+      cluster = start_link_supervised!({Xandra.Cluster, opts})
 
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node1', node_ref: ref1}}
+      assert_receive {^test_ref, ControlConnectionMock, :init_called, _args}
 
-      assert :ok = Xandra.Cluster.activate(cluster, ref1, {{192, 0, 0, 1}, 9042})
+      send(cluster, {:discovered_peers, [{{192, 0, 0, 1}, 9042}, {{192, 0, 0, 2}, 9042}]})
       assert_pool_started(test_ref, "192.0.0.1:9042")
-
-      assert_receive {^test_ref, ControlConnectionMock, :init_called,
-                      %{address: 'node2', node_ref: ref2}}
-
-      assert :ok = Xandra.Cluster.activate(cluster, ref2, {{192, 0, 0, 2}, 9042})
       assert_pool_started(test_ref, "192.0.0.2:9042")
 
       %{{{192, 0, 0, 1}, 9042} => pid1, {{192, 0, 0, 2}, 9042} => pid2} =
@@ -505,17 +350,11 @@ defmodule Xandra.ClusterTest do
 
       assert GenServer.call(cluster, :checkout) == {:ok, pid1}
 
-      # StatusChange DOWN to bring the connection to the first node down, so that :proriority
+      # StatusChange DOWN to bring the connection to the first node down, so that :priority
       # selects the second one the next time.
 
       pool_monitor_ref = Process.monitor(pid1)
-
-      assert :ok =
-               Xandra.Cluster.update(cluster, %StatusChange{
-                 effect: "DOWN",
-                 address: {192, 0, 0, 1}
-               })
-
+      send(cluster, {:cluster_event, %StatusChange{effect: "DOWN", address: {192, 0, 0, 1}}})
       assert_receive {:DOWN, ^pool_monitor_ref, _, _, _}
 
       assert GenServer.call(cluster, :checkout) == {:ok, pid2}
@@ -532,10 +371,6 @@ defmodule Xandra.ClusterTest do
     assert_receive {^test_ref, PoolMock, :init_called, %{nodes: [^node]}}
   end
 
-  defp refute_any_pool_started(test_ref) do
-    refute_receive {^test_ref, PoolMock, :init_called, _args}, 50
-  end
-
   defp wait_for_passing(time_left, fun) when time_left < 0 do
     fun.()
   end
@@ -546,5 +381,14 @@ defmodule Xandra.ClusterTest do
     _, _ ->
       Process.sleep(100)
       wait_for_passing(time_left - 100, fun)
+  end
+
+  # TODO: remove once we have ExUnit.Callbacks.start_link_supervised!/1 (Elixir 1.14+).
+  if not function_exported?(ExUnit.Callbacks, :start_link_supervised!, 1) do
+    defp start_link_supervised!(child_spec) do
+      pid = start_supervised!(child_spec)
+      true = Process.link(pid)
+      pid
+    end
   end
 end

--- a/test/integration/clustering_integration_test.exs
+++ b/test/integration/clustering_integration_test.exs
@@ -36,7 +36,7 @@ defmodule ClusteringTest do
   end
 
   test "priority load balancing", %{keyspace: keyspace, start_options: start_options} do
-    start_options = Keyword.merge(start_options, load_balancing: :priority, autodiscovery: false)
+    start_options = Keyword.merge(start_options, load_balancing: :priority)
     {:ok, cluster} = Xandra.Cluster.start_link(start_options)
 
     assert TestHelper.await_connected(

--- a/test/integration/clustering_integration_test.exs
+++ b/test/integration/clustering_integration_test.exs
@@ -1,14 +1,11 @@
 defmodule ClusteringTest do
   use XandraTest.IntegrationCase
 
-  import ExUnit.CaptureLog
-
   alias Xandra.TestHelper
 
   test "basic interactions", %{keyspace: keyspace, start_options: start_options} do
     logger_level = Logger.level()
     on_exit(fn -> Logger.configure(level: logger_level) end)
-    Logger.configure(level: :debug)
 
     statement = "USE #{keyspace}"
 
@@ -19,18 +16,10 @@ defmodule ClusteringTest do
         nodes: ["127.0.0.1", "127.0.0.1", "127.0.0.2"]
       )
 
-    log =
-      capture_log(fn ->
-        cluster = start_supervised!({Xandra.Cluster, start_options})
-        true = Process.link(cluster)
+    cluster = start_supervised!({Xandra.Cluster, start_options})
+    true = Process.link(cluster)
 
-        assert TestHelper.await_connected(cluster, _options = [], &Xandra.execute!(&1, statement))
-
-        Process.sleep(250)
-      end)
-
-    assert log =~
-             "Control connection for 127.0.0.1:9042 was already present, shutting this one down"
+    assert TestHelper.await_connected(cluster, _options = [], &Xandra.execute!(&1, statement))
 
     assert Xandra.Cluster.execute!(TestCluster, statement, _params = [])
   end

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -13,5 +13,16 @@ defmodule Xandra.TestHelper do
       else
         flunk("exceeded maximum number of attempts")
       end
+  else
+    {:error, %Xandra.ConnectionError{reason: {:cluster, :not_connected}}} ->
+      if tries > 0 do
+        Process.sleep(50)
+        await_connected(cluster, options, fun, tries - 1)
+      else
+        flunk("exceeded maximum number of attempts")
+      end
+
+    other ->
+      other
   end
 end

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -25,4 +25,31 @@ defmodule Xandra.TestHelper do
     other ->
       other
   end
+
+  # TODO: remove once we have ExUnit.Callbacks.start_link_supervised!/1 (Elixir 1.14+).
+  if function_exported?(ExUnit.Callbacks, :start_link_supervised!, 2) do
+    defdelegate start_link_supervised!(spec), to: ExUnit.Callbacks
+    defdelegate start_link_supervised!(spec, opts), to: ExUnit.Callbacks
+  else
+    @spec start_link_supervised!(Supervisor.child_spec(), keyword) :: pid
+    def start_link_supervised!(spec, opts \\ []) do
+      pid = ExUnit.Callbacks.start_supervised!(spec, opts)
+      true = Process.link(pid)
+      pid
+    end
+  end
+
+  @spec wait_for_passing(pos_integer, (() -> result)) :: result when result: var
+  def wait_for_passing(time_left, fun)
+
+  def wait_for_passing(time_left, fun) when time_left < 0, do: fun.()
+
+  @sleep_interval 50
+  def wait_for_passing(time_left, fun) do
+    fun.()
+  catch
+    _, _ ->
+      Process.sleep(@sleep_interval)
+      wait_for_passing(time_left - @sleep_interval, fun)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,7 @@ excluded =
     nil -> [:skip_for_native_protocol_v4, :skip_for_native_protocol_v3]
   end
 
+# TODO: remove this conditional once we require Elixir 1.11+
 # We only support the nimble_lz4 library for Elixir 1.11+.
 excluded =
   if Version.match?(System.version(), "~> 1.11") do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,4 +16,4 @@ excluded =
     [:compression] ++ excluded
   end
 
-ExUnit.start(exclude: excluded ++ [:encryption])
+ExUnit.start(exclude: excluded ++ [:encryption], assert_receive_timeout: 1_000)

--- a/test/xandra/cluster/control_connection_test.exs
+++ b/test/xandra/cluster/control_connection_test.exs
@@ -1,15 +1,20 @@
 defmodule Xandra.Cluster.ControlConnectionTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+
   alias Xandra.Cluster.ControlConnection
 
   @protocol_version XandraTest.IntegrationCase.protocol_version()
 
-  test "reporting data upon successful connection" do
+  setup do
     parent = self()
     mirror_ref = make_ref()
     mirror = spawn_link(fn -> mirror(parent, mirror_ref) end)
+    %{mirror_ref: mirror_ref, mirror: mirror}
+  end
 
+  test "reporting data upon successful connection", %{mirror_ref: mirror_ref, mirror: mirror} do
     opts = [
       cluster: mirror,
       contact_points: ["127.0.0.1"],
@@ -17,16 +22,49 @@ defmodule Xandra.Cluster.ControlConnectionTest do
       autodiscovered_nodes_port: 9042
     ]
 
-    assert {:ok, _ctrl_conn} = start_supervised({ControlConnection, opts})
+    start_link_supervised!({ControlConnection, opts})
     assert_receive {^mirror_ref, {:discovered_peers, peers}}
     assert peers == [{{127, 0, 0, 1}, 9042}]
   end
 
-  test "reconnecting after the node closes its socket" do
-    parent = self()
-    mirror_ref = make_ref()
-    mirror = spawn_link(fn -> mirror(parent, mirror_ref) end)
+  test "trying all the nodes in the contact points", %{mirror_ref: mirror_ref, mirror: mirror} do
+    opts = [
+      cluster: mirror,
+      contact_points: ["bad-domain", "127.0.0.1"],
+      connection_options: [protocol_version: @protocol_version],
+      autodiscovered_nodes_port: 9042
+    ]
 
+    log =
+      capture_log(fn ->
+        start_link_supervised!({ControlConnection, opts})
+        assert_receive {^mirror_ref, {:discovered_peers, peers}}
+        assert peers == [{{127, 0, 0, 1}, 9042}]
+      end)
+
+    assert log =~ "Error connecting to bad-domain:9042: non-existing domain"
+  end
+
+  test "when all contact points are unavailable", %{mirror_ref: mirror_ref, mirror: mirror} do
+    opts = [
+      cluster: mirror,
+      contact_points: ["bad-domain", "other-bad-domain"],
+      connection_options: [protocol_version: @protocol_version],
+      autodiscovered_nodes_port: 9042
+    ]
+
+    log =
+      capture_log(fn ->
+        ctrl_conn = start_link_supervised!({ControlConnection, opts})
+        refute_receive {^mirror_ref, _}, 500
+        assert {:disconnected, _data} = :sys.get_state(ctrl_conn)
+      end)
+
+    assert log =~ "Error connecting to bad-domain:9042: non-existing domain"
+    assert log =~ "Error connecting to other-bad-domain:9042: non-existing domain"
+  end
+
+  test "reconnecting after the node closes its socket", %{mirror_ref: mirror_ref, mirror: mirror} do
     opts = [
       cluster: mirror,
       contact_points: ["127.0.0.1"],
@@ -44,11 +82,8 @@ defmodule Xandra.Cluster.ControlConnectionTest do
     assert({{:connected, _connected_node}, _data} = :sys.get_state(ctrl_conn))
   end
 
-  test "reconnecting after the node's socket errors out" do
-    parent = self()
-    mirror_ref = make_ref()
-    mirror = spawn_link(fn -> mirror(parent, mirror_ref) end)
-
+  test "reconnecting after the node's socket errors out",
+       %{mirror_ref: mirror_ref, mirror: mirror} do
     opts = [
       cluster: mirror,
       contact_points: ["127.0.0.1"],
@@ -64,6 +99,23 @@ defmodule Xandra.Cluster.ControlConnectionTest do
     send(ctrl_conn, {:tcp_error, connected_node.socket, :econnreset})
     assert_receive {^mirror_ref, {:discovered_peers, [_peer]}}
     assert({{:connected, _connected_node}, _data} = :sys.get_state(ctrl_conn))
+  end
+
+  @tag :skip
+  test "forwards cluster events to the cluster", %{mirror_ref: mirror_ref, mirror: mirror} do
+    opts = [
+      cluster: mirror,
+      contact_points: ["127.0.0.1"],
+      connection_options: [protocol_version: @protocol_version],
+      autodiscovered_nodes_port: 9042
+    ]
+
+    ctrl_conn = start_link_supervised!({ControlConnection, opts})
+
+    assert_receive {^mirror_ref, {:discovered_peers, [_peer]}}
+    assert {{:connected, _connected_node}, _data} = :sys.get_state(ctrl_conn)
+
+    flunk("TODO: simulate an event being sent to the control connection")
   end
 
   defp mirror(parent, ref) do

--- a/test/xandra/cluster/control_connection_test.exs
+++ b/test/xandra/cluster/control_connection_test.exs
@@ -3,6 +3,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
 
   import ExUnit.CaptureLog
 
+  alias Xandra.TestHelper
   alias Xandra.Cluster.ControlConnection
 
   @protocol_version XandraTest.IntegrationCase.protocol_version()
@@ -22,7 +23,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
       autodiscovered_nodes_port: 9042
     ]
 
-    start_link_supervised!({ControlConnection, opts})
+    TestHelper.start_link_supervised!({ControlConnection, opts})
     assert_receive {^mirror_ref, {:discovered_peers, peers}}
     assert peers == [{{127, 0, 0, 1}, 9042}]
   end
@@ -37,7 +38,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
 
     log =
       capture_log(fn ->
-        start_link_supervised!({ControlConnection, opts})
+        TestHelper.start_link_supervised!({ControlConnection, opts})
         assert_receive {^mirror_ref, {:discovered_peers, peers}}
         assert peers == [{{127, 0, 0, 1}, 9042}]
       end)
@@ -55,7 +56,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
 
     log =
       capture_log(fn ->
-        ctrl_conn = start_link_supervised!({ControlConnection, opts})
+        ctrl_conn = TestHelper.start_link_supervised!({ControlConnection, opts})
         refute_receive {^mirror_ref, _}, 500
         assert {:disconnected, _data} = :sys.get_state(ctrl_conn)
       end)
@@ -72,7 +73,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
       autodiscovered_nodes_port: 9042
     ]
 
-    ctrl_conn = start_link_supervised!({ControlConnection, opts})
+    ctrl_conn = TestHelper.start_link_supervised!({ControlConnection, opts})
 
     assert_receive {^mirror_ref, {:discovered_peers, [_peer]}}
     assert {{:connected, connected_node}, _data} = :sys.get_state(ctrl_conn)
@@ -91,7 +92,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
       autodiscovered_nodes_port: 9042
     ]
 
-    ctrl_conn = start_link_supervised!({ControlConnection, opts})
+    ctrl_conn = TestHelper.start_link_supervised!({ControlConnection, opts})
 
     assert_receive {^mirror_ref, {:discovered_peers, [_peer]}}
     assert {{:connected, connected_node}, _data} = :sys.get_state(ctrl_conn)
@@ -110,7 +111,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
       autodiscovered_nodes_port: 9042
     ]
 
-    ctrl_conn = start_link_supervised!({ControlConnection, opts})
+    ctrl_conn = TestHelper.start_link_supervised!({ControlConnection, opts})
 
     assert_receive {^mirror_ref, {:discovered_peers, [_peer]}}
     assert {{:connected, _connected_node}, _data} = :sys.get_state(ctrl_conn)
@@ -124,14 +125,5 @@ defmodule Xandra.Cluster.ControlConnectionTest do
     end
 
     mirror(parent, ref)
-  end
-
-  # TODO: remove once we have ExUnit.Callbacks.start_link_supervised!/1 (Elixir 1.14+).
-  if not function_exported?(ExUnit.Callbacks, :start_link_supervised!, 1) do
-    defp start_link_supervised!(child_spec) do
-      pid = start_supervised!(child_spec)
-      true = Process.link(pid)
-      pid
-    end
   end
 end

--- a/test_clustering/integration_test.exs
+++ b/test_clustering/integration_test.exs
@@ -128,7 +128,7 @@ defmodule Xandra.TestClustering.IntegrationTest do
       end)
 
     control_conn_peernames =
-      wait_for_passing(30_000, fn ->
+      TestHelper.wait_for_passing(30_000, fn ->
         for {peername, ref} <- cluster_state.node_refs do
           assert is_reference(ref)
           assert {ip, port} = peername


### PR DESCRIPTION
Closes https://github.com/lexhide/xandra/issues/226.

This work is not complete per se, but I want to avoid giant PRs.

This has the following changes visible to users:

  * `:autodiscovery` is deprecated and now it's always `true` — this seems to be in line with the officially-supproted DataStax drivers (see the [Python one](https://docs.datastax.com/en/developer/python-driver/3.25/api/cassandra/cluster/)).

Things that are still missing:

  * a strategy to connect to the "next" node in the control connection
  * a working `:priority` load-balancing strategy


cc @jvf, I can't request your review but would love your 👀 on this.