### PR TITLE
Listen for connections/disconnections and detect "down" nodes in `Xandra.Cluster`

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -385,6 +385,12 @@ defmodule Xandra do
       then the transport is SSL (see the Erlang `:ssl` module) otherwise it's
       TCP (see the `:gen_tcp` Erlang module).
       """
+    ],
+
+    # Internal, used by Xandra.Cluster.
+    registry: [
+      doc: false,
+      type: :atom
     ]
   ]
 

--- a/test/xandra/cluster/control_connection_test.exs
+++ b/test/xandra/cluster/control_connection_test.exs
@@ -46,7 +46,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
     mirror = spawn_link(fn -> mirror(parent, mirror_ref) end)
 
     registry = :"#{context.test} registry"
-    start_link_supervised!({Registry, keys: :unique, name: registry})
+    TestHelper.start_link_supervised!({Registry, keys: :unique, name: registry})
 
     %{mirror_ref: mirror_ref, mirror: mirror, registry: registry}
   end


### PR DESCRIPTION
Closes https://github.com/lexhide/xandra/issues/272.

The idea here is this:

  * We have a private `:registry` option that we can give to single connection processes. If given, connections will register themselves in a `:unique` registry under key `{{address, port}, pool_index}` and value `:up | :down`.
  * When connections connect, they update their value in the registry to `:up`. When they disconnect, they update it to `:down`.
  * `Xandra.Cluster` now starts a registry and passes the `:registry` option to all connections, passing that registry.
  * We make the control connection of a cluster one of the `:connection_listeners` (see DBConnection) for connections, so that the control connection receives `{:connected | :disconnected, connection_pid}` events.
  * Whenever the control connection receives a `:connected`/`:disconnected` event, it checks for all the connections in the registry that match the same `{address, port}`. If all of them have value `:down`, the control connection marks the host as **down**.
  * Since #285 and #286, the control connection periodically refreshes the cluster topology, so if a node comes back online or something, the control connection will get it back in its list of peers and will consider it up again. This will in turn start a pool to that node.

cc @jvf @harunzengin