### PR TITLE
Send discovered_nodes in bulk from control connection

### DIFF
--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -629,7 +629,7 @@ defmodule Xandra.Cluster do
 
   def handle_info({:discovered_hosts, hosts}, %__MODULE__{} = state) when is_list(hosts) do
     Logger.debug(
-      "Discovered hosts: #{Enum.map(hosts, &Host.format_address/1) |> Enum.join(", ")}"
+      "Discovered hosts: #{Enum.map_join(hosts, ", ", &Host.format_address/1)}"
     )
 
     state =

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -628,9 +628,7 @@ defmodule Xandra.Cluster do
   end
 
   def handle_info({:discovered_hosts, hosts}, %__MODULE__{} = state) when is_list(hosts) do
-    Logger.debug(
-      "Discovered hosts: #{Enum.map_join(hosts, ", ", &Host.format_address/1)}"
-    )
+    Logger.debug("Discovered hosts: #{Enum.map_join(hosts, ", ", &Host.format_address/1)}")
 
     state =
       Enum.reduce(hosts, state, fn %Host{} = host, acc ->

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -632,9 +632,10 @@ defmodule Xandra.Cluster do
       "Discovered hosts: #{Enum.map(hosts, &Host.format_address/1) |> Enum.join(", ")}"
     )
 
-    state = Enum.reduce(hosts, state, fn %Host{} = host, acc ->
-      update_in(acc.load_balancing_state, &state.load_balancing_module.host_added(&1, host))
-    end)
+    state =
+      Enum.reduce(hosts, state, fn %Host{} = host, acc ->
+        update_in(acc.load_balancing_state, &state.load_balancing_module.host_added(&1, host))
+      end)
 
     state = maybe_start_pools(state)
     {:noreply, state}

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -418,13 +418,13 @@ defmodule Xandra.Cluster.ControlConnection do
       })
     end)
 
-    final_peers =
-      Enum.reduce(new_peers, %{}, fn %Host{} = host, acc ->
+    {existing_peers, discovered_peers} =
+      Enum.reduce(new_peers, {%{}, %{}}, fn %Host{} = host, {existing_acc, discovered_acc} ->
         peername = Host.to_peername(host)
 
         case Map.fetch(old_peers, peername) do
           {:ok, %{status: :up}} ->
-            Map.put(acc, peername, %{host: host, status: :up})
+            {Map.put(existing_acc, peername, %{host: host, status: :up}), discovered_acc}
 
           {:ok, %{status: :down}} ->
             execute_telemetry(data, [:change_event], %{}, %{
@@ -435,7 +435,7 @@ defmodule Xandra.Cluster.ControlConnection do
             })
 
             send(data.cluster, {:host_up, host})
-            Map.put(acc, peername, %{host: host, status: :up})
+            {Map.put(existing_acc, peername, %{host: host, status: :up}), discovered_acc}
 
           :error ->
             execute_telemetry(data, [:change_event], %{}, %{
@@ -445,10 +445,14 @@ defmodule Xandra.Cluster.ControlConnection do
               source: :xandra
             })
 
-            send(data.cluster, {:host_added, host})
-            Map.put(acc, peername, %{host: host, status: :up})
+            {existing_acc, Map.put(discovered_acc, peername, %{host: host, status: :up})}
         end
       end)
+
+    discovered_hosts = Map.values(discovered_peers) |> Enum.map(fn %{host: %Host{} = host} -> host end)
+    send(data.cluster, {:discovered_hosts, discovered_hosts})
+
+    final_peers = Map.merge(existing_peers, discovered_peers)
 
     data =
       if final_peers != old_peers do

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -449,7 +449,9 @@ defmodule Xandra.Cluster.ControlConnection do
         end
       end)
 
-    discovered_hosts = Map.values(discovered_peers) |> Enum.map(fn %{host: %Host{} = host} -> host end)
+    discovered_hosts =
+      Map.values(discovered_peers) |> Enum.map(fn %{host: %Host{} = host} -> host end)
+
     send(data.cluster, {:discovered_hosts, discovered_hosts})
 
     final_peers = Map.merge(existing_peers, discovered_peers)

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -482,7 +482,9 @@ defmodule Xandra.Cluster.ControlConnection do
         end
       end)
 
-    send(data.cluster, {:discovered_hosts, discovered_hosts})
+    if discovered_hosts != [] do
+      send(data.cluster, {:discovered_hosts, discovered_hosts})
+    end
 
     final_peers =
       Enum.reduce(existing_hosts ++ discovered_hosts, %{}, fn host, acc ->

--- a/test/xandra/cluster/control_connection_test.exs
+++ b/test/xandra/cluster/control_connection_test.exs
@@ -418,7 +418,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
 
     ctrl_conn = start_control_connection!(start_options)
 
-    assert_receive {^mirror_ref, {:host_added, %Host{address: {127, 0, 0, 1}}}}
+    assert_receive {^mirror_ref, {:discovered_hosts, [%Host{address: {127, 0, 0, 1}}]}}
     assert_receive {[:xandra, :cluster, :change_event], ^telemetry_ref, _, _}
 
     parent = self()
@@ -440,7 +440,7 @@ defmodule Xandra.Cluster.ControlConnectionTest do
 
     :gen_statem.cast(ctrl_conn, {:refresh_topology, new_peers})
 
-    assert_receive {^mirror_ref, {:host_added, %Host{address: {192, 168, 1, 1}}}}
+    assert_receive {^mirror_ref, {:discovered_hosts, [%Host{address: {192, 168, 1, 1}}]}}
 
     assert_receive {[:xandra, :cluster, :change_event], ^telemetry_ref, %{},
                     %{


### PR DESCRIPTION
Introduces a new message `{:discovered_hosts, [Host.t()]}`.  I wasn't so sure about whether we should introduce a new telemetry event for this, like `:host_discovered`. Not sure how useful it would be to be able to distinguish between a `:host_added` (from cassandra gossip) and `:host_discovered` (from peers table). 

Closes https://github.com/lexhide/xandra/issues/296