### PR TITLE
bypass checks on ipv6 addresses for now

### DIFF
--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -773,7 +773,9 @@ defmodule Xandra.Cluster do
   defp start_pool(state, %Host{} = host) do
     conn_options =
       Keyword.merge(state.pool_options,
-        nodes: [Host.format_address(host)],
+        # NimbleOptions.validate! validate_node fails on ipv6 transformations
+        # nodes: Host.format_address(host)
+        nodes: [host],
         registry: state.registry,
         connection_listeners: [state.control_connection]
       )

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -727,6 +727,8 @@ defmodule Xandra.Cluster.ControlConnection do
       {host, port} ->
         %Host{address: host, port: port}
 
+      %Host{address: host, port: port} = _contact_point -> %Host{address: host, port: port}
+
       contact_point ->
         {:ok, {host, port}} = Xandra.OptionsValidators.validate_node(contact_point)
         %Host{address: host, port: port}

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -40,6 +40,10 @@ defmodule Xandra.OptionsValidators do
     end
   end
 
+  def validate_node(%Xandra.Cluster.Host{address: address, port: port}) do
+    {:ok, {address, port}}
+  end
+
   def validate_node(other) do
     {:error, "expected node to be a string or a {ip, port} tuple, got: #{inspect(other)}"}
   end

--- a/test/integration/cluster_test.exs
+++ b/test/integration/cluster_test.exs
@@ -420,8 +420,7 @@ defmodule Xandra.ClusterTest do
   end
 
   defp assert_pool_started(test_ref, %Host{} = host) do
-    node = Host.format_address(host)
-    assert_receive {^test_ref, PoolMock, :init_called, %{nodes: [^node]}}
+    assert_receive {^test_ref, PoolMock, :init_called, %{nodes: [^host]}}
   end
 
   defp refute_other_pools_started(test_ref) do


### PR DESCRIPTION
We are using this lib and the host structs are returning ipv6 addresses for our clusters. The validate_node is failing on ipv6 addresses 