### PR TITLE
Bypass checks on ipv6 addresses for now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ different ports to test different features (such as authenticationn). To run
 normal tests, do this from the root of the project:
 
 ```bash
-docker-compose up --daemon
+docker-compose up --detach
 mix test
 ```
 
-The `--daemon` flag runs the instances as daemons in the background. Give it a
+The `--detach` flag runs the instances as daemons in the background. Give it a
 minute between starting the services and running `mix test` since Cassandra
 takes a while to start. You can check whether the Docker containers are ready
 with `docker-compose ps`. To stop the services, run `docker-compose stop`.

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -782,8 +782,6 @@ defmodule Xandra.Cluster do
 
     peername = Host.to_peername(host)
 
-    IO.puts("start_pool - state.xandra_mod #{inspect(state.xandra_mod)}")
-
     pool_spec =
       Supervisor.child_spec({state.xandra_mod, conn_options},
         id: peername,

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -437,7 +437,7 @@ defmodule Xandra.Cluster do
       raise ArgumentError, "the :sync_connect option is only supported on Erlang/OTP 24+"
     end
 
-    defp unalias(alias), do: raise(ArgumentError, "should never reach this")
+    defp unalias(_alias), do: raise(ArgumentError, "should never reach this")
   end
 
   @doc """

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -782,6 +782,8 @@ defmodule Xandra.Cluster do
 
     peername = Host.to_peername(host)
 
+    IO.puts("start_pool - state.xandra_mod #{inspect(state.xandra_mod)}")
+
     pool_spec =
       Supervisor.child_spec({state.xandra_mod, conn_options},
         id: peername,

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -773,7 +773,9 @@ defmodule Xandra.Cluster do
   defp start_pool(state, %Host{} = host) do
     conn_options =
       Keyword.merge(state.pool_options,
-        nodes: [Host.format_address(host)],
+        # NimbleOptions.validate! validate_node fails on ipv6 transformations
+        # nodes: Host.format_address(host)
+        nodes: [host],
         registry: state.registry,
         connection_listeners: [state.control_connection]
       )

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -773,8 +773,6 @@ defmodule Xandra.Cluster do
   defp start_pool(state, %Host{} = host) do
     conn_options =
       Keyword.merge(state.pool_options,
-        # NimbleOptions.validate! validate_node fails on ipv6 transformations
-        # nodes: Host.format_address(host)
         nodes: [host],
         registry: state.registry,
         connection_listeners: [state.control_connection]

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -162,12 +162,6 @@ defmodule Xandra.Cluster.ControlConnection do
   def handle_event(:internal, :connect, :disconnected, %__MODULE__{} = data) do
     case connect_to_first_available_node(data) do
       {:ok, connected_node, peers} ->
-        IO.puts(
-          "\nhandle_event(:internal, :connect, :disconnected, data) ... SUCCESSFULLY connected, connected_node: address: #{inspect(connected_node.host.address)} port: #{inspect(connected_node.host.port)}}\n"
-        )
-
-        IO.puts("\tpeers: #{inspect(peers)}")
-
         data = refresh_topology(data, peers)
         {:next_state, {:connected, connected_node}, data}
 
@@ -373,8 +367,6 @@ defmodule Xandra.Cluster.ControlConnection do
   end
 
   defp connect_to_first_available_node([%Host{} = host | nodes], data) do
-    IO.puts("connect_to_first_available_node host #{inspect(host)}")
-
     case connect_to_node({host.address, host.port}, data) do
       {:ok, %ConnectedNode{}, _peers} = return ->
         return
@@ -737,8 +729,6 @@ defmodule Xandra.Cluster.ControlConnection do
         %Host{address: host, port: port}
 
       %Host{address: host, port: port} = _contact_point ->
-        IO.puts("contact_points_to_hosts address: #{inspect(host)}, port: #{port}")
-
         %Host{address: host, port: port}
 
       contact_point ->

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -163,7 +163,7 @@ defmodule Xandra.Cluster.ControlConnection do
     case connect_to_first_available_node(data) do
       {:ok, connected_node, peers} ->
         IO.puts(
-          "\nhandle_event(:internal, :connect, :disconnected, data) ... SUCCESSFULLY connected, connected_node: #{inspect(connected_node.host)}\n"
+          "\nhandle_event(:internal, :connect, :disconnected, data) ... SUCCESSFULLY connected, connected_node: address: #{inspect(connected_node.host.address)} port: #{inspect(connected_node.host.port)}}\n"
         )
 
         data = refresh_topology(data, peers)

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -728,6 +728,8 @@ defmodule Xandra.Cluster.ControlConnection do
         %Host{address: host, port: port}
 
       %Host{address: host, port: port} = _contact_point ->
+        IO.puts("contact_points_to_hosts address: #{inspect(host)}, port: #{port}")
+
         %Host{address: host, port: port}
 
       contact_point ->

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -163,7 +163,7 @@ defmodule Xandra.Cluster.ControlConnection do
     case connect_to_first_available_node(data) do
       {:ok, connected_node, peers} ->
         IO.puts(
-          "handle_event(:internal, :connect, :disconnected, data) ... successfully connected, connected_node: #{connected_node}, peers: #{peers}"
+          "handle_event(:internal, :connect, :disconnected, data) ... successfully connected, connected_node: #{inspect(connected_node)}, peers: #{inspect(peers)}"
         )
 
         data = refresh_topology(data, peers)

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -706,7 +706,7 @@ defmodule Xandra.Cluster.ControlConnection do
     end
   end
 
-  defp queried_peer_to_host(%{"peer" => _} = peer_attrs) do
+  defp queried_peer_to_host(%{"rpc_address" => _} = peer_attrs) do
     {address, peer_attrs} = Map.pop!(peer_attrs, "rpc_address")
     peer_attrs = Map.put(peer_attrs, "address", address)
     queried_peer_to_host(peer_attrs)
@@ -719,7 +719,6 @@ defmodule Xandra.Cluster.ControlConnection do
       "host_id",
       "rack",
       "release_version",
-      "rpc_address",
       "schema_version",
       "tokens"
     ]

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -233,7 +233,8 @@ defmodule Xandra.Cluster.ControlConnection do
       "SELECT peer, data_center, host_id, rack, release_version, schema_version, tokens FROM system.peers"
 
     with {:ok, peers} <- query(data, connected_node, select_peers_query),
-         host when not is_nil(host) <- Enum.find(peers, fn peer -> peer["peer"] == address end) do
+         host when not is_nil(host) <-
+           Enum.find(peers, fn peer -> peer["rpc_address"] == address end) do
       new_host = queried_peer_to_host(host)
       new_host = %Host{new_host | port: data.autodiscovered_nodes_port}
 

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -166,6 +166,8 @@ defmodule Xandra.Cluster.ControlConnection do
           "\nhandle_event(:internal, :connect, :disconnected, data) ... SUCCESSFULLY connected, connected_node: address: #{inspect(connected_node.host.address)} port: #{inspect(connected_node.host.port)}}\n"
         )
 
+        IO.puts("\tpeers: #{inspect(peers)}")
+
         data = refresh_topology(data, peers)
         {:next_state, {:connected, connected_node}, data}
 
@@ -705,7 +707,7 @@ defmodule Xandra.Cluster.ControlConnection do
   end
 
   defp queried_peer_to_host(%{"peer" => _} = peer_attrs) do
-    {address, peer_attrs} = Map.pop!(peer_attrs, "peer")
+    {address, peer_attrs} = Map.pop!(peer_attrs, "rpc_address")
     peer_attrs = Map.put(peer_attrs, "address", address)
     queried_peer_to_host(peer_attrs)
   end

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -232,7 +232,7 @@ defmodule Xandra.Cluster.ControlConnection do
         %__MODULE__{} = data
       ) do
     select_peers_query =
-      "SELECT peer, data_center, host_id, rack, release_version, schema_version, tokens FROM system.peers"
+      "SELECT peer, data_center, host_id, rack, release_version, rpc_address, schema_version, tokens FROM system.peers"
 
     with {:ok, peers} <- query(data, connected_node, select_peers_query),
          host when not is_nil(host) <-
@@ -719,6 +719,7 @@ defmodule Xandra.Cluster.ControlConnection do
       "host_id",
       "rack",
       "release_version",
+      "rpc_address",
       "schema_version",
       "tokens"
     ]

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -367,6 +367,7 @@ defmodule Xandra.Cluster.ControlConnection do
 
   defp connect_to_first_available_node([%Host{} = host | nodes], data) do
     IO.puts("connect_to_first_available_node host #{inspect(host)}")
+
     case connect_to_node({host.address, host.port}, data) do
       {:ok, %ConnectedNode{}, _peers} = return ->
         return

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -366,6 +366,7 @@ defmodule Xandra.Cluster.ControlConnection do
   end
 
   defp connect_to_first_available_node([%Host{} = host | nodes], data) do
+    IO.puts("connect_to_first_available_node host #{inspect(host)}")
     case connect_to_node({host.address, host.port}, data) do
       {:ok, %ConnectedNode{}, _peers} = return ->
         return

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -727,7 +727,8 @@ defmodule Xandra.Cluster.ControlConnection do
       {host, port} ->
         %Host{address: host, port: port}
 
-      %Host{address: host, port: port} = _contact_point -> %Host{address: host, port: port}
+      %Host{address: host, port: port} = _contact_point ->
+        %Host{address: host, port: port}
 
       contact_point ->
         {:ok, {host, port}} = Xandra.OptionsValidators.validate_node(contact_point)

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -163,7 +163,7 @@ defmodule Xandra.Cluster.ControlConnection do
     case connect_to_first_available_node(data) do
       {:ok, connected_node, peers} ->
         IO.puts(
-          "handle_event(:internal, :connect, :disconnected, data) ... successfully connected, connected_node: #{inspect(connected_node)}, peers: #{inspect(peers)}"
+          "\nhandle_event(:internal, :connect, :disconnected, data) ... SUCCESSFULLY connected, connected_node: #{inspect(connected_node.host)}\n"
         )
 
         data = refresh_topology(data, peers)

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -530,7 +530,7 @@ defmodule Xandra.Cluster.ControlConnection do
     select_peers_query = "SELECT * FROM system.peers"
 
     select_local_query =
-      "SELECT data_center, host_id, rack, release_version, schema_version, tokens FROM system.local"
+      "SELECT data_center, host_id, rack, release_version, rpc_address, schema_version, tokens FROM system.local"
 
     with {:ok, [local_node_info]} <- query(data, node, select_local_query),
          {:ok, peers} <- query(data, node, select_peers_query) do

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -727,6 +727,8 @@ defmodule Xandra.Cluster.ControlConnection do
       {host, port} ->
         %Host{address: host, port: port}
 
+      %Host{address: host, port: port} = _contact_point -> %Host{address: host, port: port}
+
       contact_point ->
         {:ok, {host, port}} = Xandra.OptionsValidators.validate_node(contact_point)
         %Host{address: host, port: port}

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -162,6 +162,10 @@ defmodule Xandra.Cluster.ControlConnection do
   def handle_event(:internal, :connect, :disconnected, %__MODULE__{} = data) do
     case connect_to_first_available_node(data) do
       {:ok, connected_node, peers} ->
+        IO.puts(
+          "handle_event(:internal, :connect, :disconnected, data) ... successfully connected, connected_node: #{connected_node}, peers: #{peers}"
+        )
+
         data = refresh_topology(data, peers)
         {:next_state, {:connected, connected_node}, data}
 

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -530,7 +530,7 @@ defmodule Xandra.Cluster.ControlConnection do
     select_peers_query = "SELECT * FROM system.peers"
 
     select_local_query =
-      "SELECT data_center, host_id, rack, release_version, rpc_address, schema_version, tokens FROM system.local"
+      "SELECT data_center, host_id, rack, release_version, schema_version, tokens FROM system.local"
 
     with {:ok, [local_node_info]} <- query(data, node, select_local_query),
          {:ok, peers} <- query(data, node, select_peers_query) do

--- a/lib/xandra/cluster/host.ex
+++ b/lib/xandra/cluster/host.ex
@@ -32,7 +32,6 @@ defmodule Xandra.Cluster.Host do
     :host_id,
     :rack,
     :release_version,
-    :rpc_address,
     :schema_version,
     :tokens
   ]

--- a/lib/xandra/cluster/host.ex
+++ b/lib/xandra/cluster/host.ex
@@ -32,6 +32,7 @@ defmodule Xandra.Cluster.Host do
     :host_id,
     :rack,
     :release_version,
+    :rpc_address,
     :schema_version,
     :tokens
   ]

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -40,6 +40,7 @@ defmodule Xandra.Connection do
       |> Keyword.get(:transport_options, [])
       |> Keyword.merge(@forced_transport_options)
 
+      IO.puts("CALLING transport.connect #{transport} (address: #{inspect(address)}, port: #{inspect(port)}, transport_options: #{inspect(transport_options)})")
     case transport.connect(address, port, transport_options, @default_timeout) do
       {:ok, socket} ->
         {:ok, peername} = inet_mod(transport).peername(socket)

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -40,7 +40,10 @@ defmodule Xandra.Connection do
       |> Keyword.get(:transport_options, [])
       |> Keyword.merge(@forced_transport_options)
 
-      IO.puts("CALLING transport.connect #{transport} (address: #{inspect(address)}, port: #{inspect(port)}, transport_options: #{inspect(transport_options)})")
+    IO.puts(
+      "CALLING transport.connect #{transport} (address: #{inspect(address)}, port: #{inspect(port)}, transport_options: #{inspect(transport_options)})"
+    )
+
     case transport.connect(address, port, transport_options, @default_timeout) do
       {:ok, socket} ->
         {:ok, peername} = inet_mod(transport).peername(socket)

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -42,7 +42,8 @@ defmodule Xandra.Connection do
       |> Keyword.get(:transport_options, [])
       |> Keyword.merge(@forced_transport_options)
 
-    log_info = "#{transport}.connect(address: #{inspect(address)}, port: #{inspect(port)}, transport_options: #{inspect(transport_options)})"
+    log_info =
+      "#{transport}.connect(address: #{inspect(address)}, port: #{inspect(port)}, transport_options: #{inspect(transport_options)})"
 
     case transport.connect(address, port, transport_options, @default_timeout) do
       {:ok, socket} ->

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -53,15 +53,6 @@ defmodule Xandra.OptionsValidators do
       _valid_address ->
         {:ok, {address, port}}
     end
-
-    # case :inet.ntoa(address) do
-    #   {:error, :einval} ->
-    #     {:error,
-    #      "expected valid address, got: tuple address: #{inspect(address)} and port: #{inspect(port)}, with error: :einval"}
-
-    #   valid_address ->
-    #     {:ok, {valid_address, port}}
-    # end
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_list(address) do
@@ -75,15 +66,6 @@ defmodule Xandra.OptionsValidators do
         {:error,
          "expected valid address list, got: address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
     end
-
-    # case :inet.parse_address(address) do
-    #   {:ok, _} ->
-    #     {:ok, {address, port}}
-
-    #   error ->
-    #     {:error,
-    #      "expected valid address, got: list address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
-    # end
   end
 
   def validate_node(other) do

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -41,6 +41,7 @@ defmodule Xandra.OptionsValidators do
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) do
+    IO.puts("validate_node address: #{inspect(address)}, port: #{port}")
     {:ok, {address, port}}
   end
 

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -29,6 +29,7 @@ defmodule Xandra.OptionsValidators do
   @spec validate_node(term()) :: {:ok, {charlist(), integer()}} | {:error, String.t()}
   def validate_node(value) when is_binary(value) do
     IO.puts("validate_node binary: #{inspect(value)}")
+
     case String.split(value, ":", parts: 2) do
       [address, port] ->
         case Integer.parse(port) do
@@ -43,6 +44,7 @@ defmodule Xandra.OptionsValidators do
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_tuple(address) do
     IO.puts("validate_node tuple address: #{inspect(address)}, port: #{port}")
+
     case :inet.ntoa(address) do
       {:error, :einval} ->
         {:error,
@@ -55,6 +57,7 @@ defmodule Xandra.OptionsValidators do
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_list(address) do
     IO.puts("validate_node list address: #{inspect(address)}, port: #{port}")
+
     case :inet.parse_address(address) do
       {:ok, _} ->
         {:ok, {address, port}}

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -40,6 +40,10 @@ defmodule Xandra.OptionsValidators do
     end
   end
 
+  def validate_node(%Xandra.Cluster.Host{address: address, port: port}) do
+    {:ok, {address, port}}
+  end
+
   def validate_node(other) do
     {:error, "expected node to be a string or a {ip, port} tuple, got: #{inspect(other)}"}
   end

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -28,8 +28,6 @@ defmodule Xandra.OptionsValidators do
 
   @spec validate_node(term()) :: {:ok, {charlist(), integer()}} | {:error, String.t()}
   def validate_node(value) when is_binary(value) do
-    IO.puts("validate_node binary: #{inspect(value)}")
-
     case String.split(value, ":", parts: 2) do
       [address, port] ->
         case Integer.parse(port) do
@@ -43,8 +41,6 @@ defmodule Xandra.OptionsValidators do
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_tuple(address) do
-    IO.puts("validate_node tuple address: #{inspect(address)}, port: #{port}")
-
     case :inet.ntoa(address) do
       {:error, :einval} ->
         {:error,
@@ -56,8 +52,6 @@ defmodule Xandra.OptionsValidators do
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_list(address) do
-    IO.puts("validate_node list address: #{inspect(address)}, port: #{port}")
-
     case :inet.parse_address(address) do
       {:ok, valid_address} ->
         {:ok, {valid_address, port}}

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -40,9 +40,18 @@ defmodule Xandra.OptionsValidators do
     end
   end
 
-  def validate_node(%Xandra.Cluster.Host{address: address, port: port}) do
-    IO.puts("validate_node address: #{inspect(address)}, port: #{port}")
-    {:ok, {address, port}}
+  def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_tuple(address) do
+    case :inet.ntoa(address) do
+      {:error, :einval} -> {:error, "expected valid address, got: tuple address: #{inspect(address)} and port: #{inspect(port)}, with error: :einval"}
+      valid_address -> {:ok, {valid_address, port}}
+    end
+  end
+
+  def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_list(address) do
+    case :inet.parse_address(address) do
+      {:ok, _} -> {:ok, {address, port}}
+      error -> {:error, "expected valid address, got: list address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
+    end
   end
 
   def validate_node(other) do

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -28,6 +28,7 @@ defmodule Xandra.OptionsValidators do
 
   @spec validate_node(term()) :: {:ok, {charlist(), integer()}} | {:error, String.t()}
   def validate_node(value) when is_binary(value) do
+    IO.puts("validate_node binary: #{inspect(value)}")
     case String.split(value, ":", parts: 2) do
       [address, port] ->
         case Integer.parse(port) do
@@ -41,6 +42,7 @@ defmodule Xandra.OptionsValidators do
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_tuple(address) do
+    IO.puts("validate_node tuple address: #{inspect(address)}, port: #{port}")
     case :inet.ntoa(address) do
       {:error, :einval} ->
         {:error,
@@ -52,6 +54,7 @@ defmodule Xandra.OptionsValidators do
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_list(address) do
+    IO.puts("validate_node list address: #{inspect(address)}, port: #{port}")
     case :inet.parse_address(address) do
       {:ok, _} ->
         {:ok, {address, port}}

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -42,15 +42,23 @@ defmodule Xandra.OptionsValidators do
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_tuple(address) do
     case :inet.ntoa(address) do
-      {:error, :einval} -> {:error, "expected valid address, got: tuple address: #{inspect(address)} and port: #{inspect(port)}, with error: :einval"}
-      valid_address -> {:ok, {valid_address, port}}
+      {:error, :einval} ->
+        {:error,
+         "expected valid address, got: tuple address: #{inspect(address)} and port: #{inspect(port)}, with error: :einval"}
+
+      valid_address ->
+        {:ok, {valid_address, port}}
     end
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_list(address) do
     case :inet.parse_address(address) do
-      {:ok, _} -> {:ok, {address, port}}
-      error -> {:error, "expected valid address, got: list address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
+      {:ok, _} ->
+        {:ok, {address, port}}
+
+      error ->
+        {:error,
+         "expected valid address, got: list address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
     end
   end
 

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -48,24 +48,42 @@ defmodule Xandra.OptionsValidators do
     case :inet.ntoa(address) do
       {:error, :einval} ->
         {:error,
-         "expected valid address, got: tuple address: #{inspect(address)} and port: #{inspect(port)}, with error: :einval"}
+         "expected valid address tuple, got: address: #{inspect(address)} and port: #{inspect(port)}, with error: :einval"}
 
-      valid_address ->
-        {:ok, {valid_address, port}}
+      _valid_address ->
+        {:ok, {address, port}}
     end
+
+    # case :inet.ntoa(address) do
+    #   {:error, :einval} ->
+    #     {:error,
+    #      "expected valid address, got: tuple address: #{inspect(address)} and port: #{inspect(port)}, with error: :einval"}
+
+    #   valid_address ->
+    #     {:ok, {valid_address, port}}
+    # end
   end
 
   def validate_node(%Xandra.Cluster.Host{address: address, port: port}) when is_list(address) do
     IO.puts("validate_node list address: #{inspect(address)}, port: #{port}")
 
     case :inet.parse_address(address) do
-      {:ok, _} ->
-        {:ok, {address, port}}
+      {:ok, valid_address} ->
+        {:ok, {valid_address, port}}
 
       error ->
         {:error,
-         "expected valid address, got: list address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
+         "expected valid address list, got: address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
     end
+
+    # case :inet.parse_address(address) do
+    #   {:ok, _} ->
+    #     {:ok, {address, port}}
+
+    #   error ->
+    #     {:error,
+    #      "expected valid address, got: list address: #{inspect(address)} and port: #{inspect(port)}, with error: #{inspect(error)}"}
+    # end
   end
 
   def validate_node(other) do

--- a/test/integration/cluster_test.exs
+++ b/test/integration/cluster_test.exs
@@ -420,8 +420,7 @@ defmodule Xandra.ClusterTest do
   end
 
   defp assert_pool_started(test_ref, %Host{} = host) do
-    node = Host.format_address(host)
-    assert_receive {^test_ref, PoolMock, :init_called, %{nodes: [^node]}}
+    assert_receive {^test_ref, PoolMock, :init_called, %{nodes: [^host]}}
   end
 
   defp refute_other_pools_started(test_ref) do


### PR DESCRIPTION
We are using this lib and the host structs are returning ipv6 addresses for our clusters. The `validate_node` function is failing on ipv6 addresses

"The pool supervisor will run the validations again on the ipv6 values returned in https://github.com/lexhide/xandra/blob/v0.16.0/lib/xandra/cluster.ex#L793 and in the logs we see that our hosts are returned with both ipv4 and ipv6 addresses. The ipv6 addresses are being used and fail to validate." - @britto 

```
invalid value for list element at position 0: invalid node: \"xxxx:xxxx:xxxx:xxxx:0:xxx:xxxx:xxxx:xxxxx\"", value: ["xxxx:xxxx:xxxx:xxxx:0:xxx:xxxx:xxxx:xxxxx"]}, [{NimbleOptions, :validate!, 2, [file: 'lib/nimble_options.ex', line: 343]}
```
```
     (xandra 0.16.0) lib/xandra/cluster.ex:750: Xandra.Cluster.start_pool/2
     (xandra 0.16.0) lib/xandra/cluster.ex:798: anonymous fn/4 in Xandra.Cluster.maybe_start_pools/1
     (elixir 1.12.3) lib/enum.ex:4286: Enumerable.List.reduce/3
     (elixir 1.12.3) lib/enum.ex:2431: Enum.reduce_while/3
     (xandra 0.16.0) lib/xandra/cluster.ex:726: Xandra.Cluster.handle_info/2
     (stdlib 3.17.2) gen_server.erl:695: :gen_server.try_dispatch/4
     (stdlib 3.17.2) gen_server.erl:771: :gen_server.handle_msg/6
```