### PR TITLE
Support IPv6 nodes and transport options

### DIFF
--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -444,7 +444,7 @@ defmodule Xandra do
       """
     ],
     transport_options: [
-      type: {:list, {:or, [:keyword, :atom, :any]}},
+      type: {:or, [:keyword_list, {:list, :any}]},
       doc: """
       Options to forward to the socket transport. If the `:encryption` option is `true`,
       then the transport is SSL (see the Erlang `:ssl` module) otherwise it's

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -444,7 +444,7 @@ defmodule Xandra do
       """
     ],
     transport_options: [
-      type: :keyword_list,
+      type: {:list, {:or, [:keyword, :atom, :any]}},
       doc: """
       Options to forward to the socket transport. If the `:encryption` option is `true`,
       then the transport is SSL (see the Erlang `:ssl` module) otherwise it's

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -420,8 +420,9 @@ defmodule Xandra do
       The Cassandra node to connect to. This option is a list for consistency with
       `Xandra.Cluster`, but if using `Xandra` directly, it can only contain a single node.
       Such node can have the form `"ADDRESS:PORT"`, or `"ADDRESS"` (port defaults to
-      `9042`). See the documentation for `Xandra.Cluster` for more information on
-      connecting to multiple nodes.
+      `9042`). IPv6 addresses with an explicit port must use bracket notation, such as
+      `"[::1]:9042"`. See the documentation for `Xandra.Cluster` for more information
+      on connecting to multiple nodes.
       """
     ],
     protocol_version: [
@@ -444,7 +445,7 @@ defmodule Xandra do
       """
     ],
     transport_options: [
-      type: {:or, [:keyword_list, {:list, :any}]},
+      type: {:list, :any},
       doc: """
       Options to forward to the socket transport. If the `:encryption` option is `true`,
       then the transport is SSL (see the Erlang `:ssl` module) otherwise it's

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -102,9 +102,13 @@ defmodule Xandra.Cluster.ControlConnection do
 
     {transport_opts, connection_opts} = Keyword.pop(connection_opts, :transport_options, [])
 
+    # Construct the transport options.
+    {keyword_options, other_options} =
+      Enum.split_with(transport_opts, fn x -> Keyword.keyword?([x]) end)
+
     transport = %Transport{
       module: module,
-      options: Keyword.merge(transport_opts, @forced_transport_options)
+      options: Keyword.merge(keyword_options, @forced_transport_options) ++ other_options
     }
 
     {transport, connection_opts}

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -102,13 +102,9 @@ defmodule Xandra.Cluster.ControlConnection do
 
     {transport_opts, connection_opts} = Keyword.pop(connection_opts, :transport_options, [])
 
-    # Construct the transport options.
-    {keyword_options, other_options} =
-      Enum.split_with(transport_opts, fn x -> Keyword.keyword?([x]) end)
-
     transport = %Transport{
       module: module,
-      options: Keyword.merge(keyword_options, @forced_transport_options) ++ other_options
+      options: transport_opts ++ @forced_transport_options
     }
 
     {transport, connection_opts}

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -409,16 +409,21 @@ defmodule Xandra.Connection do
         nil -> data.original_options
       end
 
+    # Construct the transport options.
+    {options, other_options} =
+      options
+      |> Keyword.get(:transport_options, [])
+      |> Enum.split_with(fn x -> Keyword.keyword?([x]) end)
+
     # Now, build the state from the options.
     {address, port} = Keyword.fetch!(options, :node)
 
     transport = %Transport{
       module: if(options[:encryption], do: :ssl, else: :gen_tcp),
       options:
-        options
-        |> Keyword.get(:transport_options, [])
-        |> Keyword.put_new(:buffer, @default_transport_buffer_size)
-        |> Keyword.merge(@forced_transport_options)
+        (options
+         |> Keyword.put_new(:buffer, @default_transport_buffer_size)
+         |> Keyword.merge(@forced_transport_options)) ++ other_options
     }
 
     data = %__MODULE__{

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -410,7 +410,7 @@ defmodule Xandra.Connection do
       end
 
     # Construct the transport options.
-    {options, other_options} =
+    {keyword_options, other_options} =
       options
       |> Keyword.get(:transport_options, [])
       |> Enum.split_with(fn x -> Keyword.keyword?([x]) end)
@@ -421,7 +421,7 @@ defmodule Xandra.Connection do
     transport = %Transport{
       module: if(options[:encryption], do: :ssl, else: :gen_tcp),
       options:
-        (options
+        (keyword_options
          |> Keyword.put_new(:buffer, @default_transport_buffer_size)
          |> Keyword.merge(@forced_transport_options)) ++ other_options
     }

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -409,21 +409,14 @@ defmodule Xandra.Connection do
         nil -> data.original_options
       end
 
-    # Construct the transport options.
-    {keyword_options, other_options} =
-      options
-      |> Keyword.get(:transport_options, [])
-      |> Enum.split_with(fn x -> Keyword.keyword?([x]) end)
-
     # Now, build the state from the options.
     {address, port} = Keyword.fetch!(options, :node)
 
     transport = %Transport{
       module: if(options[:encryption], do: :ssl, else: :gen_tcp),
       options:
-        (keyword_options
-         |> Keyword.put_new(:buffer, @default_transport_buffer_size)
-         |> Keyword.merge(@forced_transport_options)) ++ other_options
+        [buffer: @default_transport_buffer_size] ++
+          Keyword.get(options, :transport_options, []) ++ @forced_transport_options
     }
 
     data = %__MODULE__{

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -30,40 +30,61 @@ defmodule Xandra.OptionsValidators do
 
   @spec validate_node(term()) :: {:ok, {String.t(), integer()}} | {:error, String.t()}
   def validate_node(value) when is_binary(value) do
-    # Remove surrounding square brackets from IPv6 values.
-    value = value |> String.replace("[", "") |> String.replace("]", "")
+    case Regex.run(~r/^\[([^\]]+)\](?::([^:]+))?$/, value) do
+      [_, address] ->
+        validate_ipv6_node(address, 9042, value)
 
-    {address, port} =
-      case String.split(value, ":") do
-        # FQDN or IPv4.
-        [address] ->
-          {address, "9042"}
+      [_, address, port] ->
+        with {:ok, port} <- validate_port(port, value) do
+          validate_ipv6_node(address, port, value)
+        end
 
-        # FQDN:PORT or IPv4:PORT. IPv6 addresses have to have at least 2 colons.
-        [address, port] ->
-          {address, port}
-
-        # IPv6.
-        splits ->
-          # Our IPv6 address can either parse as a valid address or have the
-          # additional port suffix.
-          with {:ok, {_, _, _, _, _, _, _, _}} <-
-                 :inet.parse_address(value |> String.to_charlist()) do
-            {value, "9042"}
-          else
-            _ -> {splits |> Enum.drop(-1) |> Enum.join(":"), List.last(splits)}
-          end
-      end
-
-    case Integer.parse(port) do
-      {port, ""} when port in 0..65535 -> {:ok, {address, port}}
-      {port, ""} -> {:error, "invalid port (outside of the 0..65535 range): #{port}"}
-      _ -> {:error, "invalid node: #{inspect(value)}"}
+      nil ->
+        validate_unbracketed_node(value)
     end
   end
 
   def validate_node(other) do
     {:error, "expected node to be a \"<host>:<port>\" string, got: #{inspect(other)}"}
+  end
+
+  defp validate_unbracketed_node(value) do
+    cond do
+      String.contains?(value, ["[", "]"]) ->
+        {:error, "invalid node: #{inspect(value)}"}
+
+      ipv6_address?(value) ->
+        {:ok, {value, 9042}}
+
+      true ->
+        case String.split(value, ":", parts: 2) do
+          [address, port] ->
+            with {:ok, port} <- validate_port(port, value), do: {:ok, {address, port}}
+
+          [address] ->
+            {:ok, {address, 9042}}
+        end
+    end
+  end
+
+  defp validate_ipv6_node(address, port, original_value) do
+    if ipv6_address?(address) do
+      {:ok, {address, port}}
+    else
+      {:error, "invalid node: #{inspect(original_value)}"}
+    end
+  end
+
+  defp ipv6_address?(address) do
+    match?({:ok, {_, _, _, _, _, _, _, _}}, :inet.parse_address(String.to_charlist(address)))
+  end
+
+  defp validate_port(port, original_value) do
+    case Integer.parse(port) do
+      {port, ""} when port in 0..65535 -> {:ok, port}
+      {port, ""} -> {:error, "invalid port (outside of the 0..65535 range): #{port}"}
+      _ -> {:error, "invalid node: #{inspect(original_value)}"}
+    end
   end
 
   @spec validate_contact_node(term()) :: {:ok, Host.t()} | {:error, String.t()}

--- a/test/xandra/cluster_test.exs
+++ b/test/xandra/cluster_test.exs
@@ -147,6 +147,19 @@ defmodule Xandra.ClusterTest do
         Xandra.Cluster.start_link(port: 9042)
       end
     end
+
+    test "with the :inet6 transport option" do
+      assert {:ok, _conn} = Xandra.Cluster.start_link(nodes: ["::1"], transport_options: [:inet6])
+
+      assert {:ok, _conn} =
+               Xandra.Cluster.start_link(nodes: ["::1:9042"], transport_options: [:inet6])
+
+      assert {:ok, _conn} =
+               Xandra.Cluster.start_link(nodes: ["[::1]"], transport_options: [:inet6])
+
+      assert {:ok, _conn} =
+               Xandra.Cluster.start_link(nodes: ["[::1]:9042"], transport_options: [:inet6])
+    end
   end
 
   describe "start_link/1" do

--- a/test/xandra/cluster_test.exs
+++ b/test/xandra/cluster_test.exs
@@ -270,6 +270,16 @@ defmodule Xandra.ClusterTest do
       assert GenServer.whereis(name) == pid
       stop_supervised!(name)
     end
+
+    @tag telemetry_events: [[:xandra, :connected]]
+    test "successfully connect even with an invalid transport option",
+         %{base_options: opts, telemetry_ref: telemetry_ref} do
+      opts = Keyword.merge(opts, transport_options: [active: true])
+      _pid = start_link_supervised!({Cluster, opts})
+
+      # Assert that we already received events.
+      assert_received {[:xandra, :connected], ^telemetry_ref, %{}, %{}}
+    end
   end
 
   describe "starting up" do

--- a/test/xandra/cluster_test.exs
+++ b/test/xandra/cluster_test.exs
@@ -152,7 +152,10 @@ defmodule Xandra.ClusterTest do
       assert {:ok, _conn} = Xandra.Cluster.start_link(nodes: ["::1"], transport_options: [:inet6])
 
       assert {:ok, _conn} =
-               Xandra.Cluster.start_link(nodes: ["::1:9042"], transport_options: [:inet6])
+               Xandra.Cluster.start_link(
+                 nodes: ["2001:db8::1:9042"],
+                 transport_options: [:inet6]
+               )
 
       assert {:ok, _conn} =
                Xandra.Cluster.start_link(nodes: ["[::1]"], transport_options: [:inet6])

--- a/test/xandra/options_validators_test.exs
+++ b/test/xandra/options_validators_test.exs
@@ -1,0 +1,31 @@
+defmodule Xandra.OptionsValidatorsTest do
+  use ExUnit.Case, async: true
+
+  alias Xandra.OptionsValidators
+
+  describe "validate_node/1" do
+    test "parses unbracketed IPv6 addresses without a port" do
+      assert OptionsValidators.validate_node("::1") == {:ok, {"::1", 9042}}
+
+      assert OptionsValidators.validate_node("2001:db8::1:9042") ==
+               {:ok, {"2001:db8::1:9042", 9042}}
+    end
+
+    test "requires brackets around IPv6 addresses with an explicit port" do
+      assert OptionsValidators.validate_node("[::1]:9043") == {:ok, {"::1", 9043}}
+      assert OptionsValidators.validate_node("[::1]") == {:ok, {"::1", 9042}}
+    end
+
+    test "rejects malformed bracket notation" do
+      assert {:error, _message} = OptionsValidators.validate_node("[::1:9043")
+      assert {:error, _message} = OptionsValidators.validate_node("::1]:9043")
+      assert {:error, _message} = OptionsValidators.validate_node("[example.com]:9043")
+    end
+
+    test "parses hostnames and IPv4 addresses as before" do
+      assert OptionsValidators.validate_node("localhost") == {:ok, {"localhost", 9042}}
+      assert OptionsValidators.validate_node("localhost:9043") == {:ok, {"localhost", 9043}}
+      assert OptionsValidators.validate_node("127.0.0.1:9043") == {:ok, {"127.0.0.1", 9043}}
+    end
+  end
+end

--- a/test/xandra/transport_test.exs
+++ b/test/xandra/transport_test.exs
@@ -17,6 +17,18 @@ defmodule Xandra.TransportTest do
       assert %Transport{} = transport = Transport.close(transport)
       assert transport.socket == nil
     end
+
+    test "returns an IPv6-compatible transport" do
+      assert {:ok, listen_socket} = :gen_tcp.listen(0, [:inet6])
+      assert {:ok, port} = :inet.port(listen_socket)
+
+      transport = %Transport{module: :gen_tcp, options: [:inet6]}
+      assert {:ok, transport} = Transport.connect(transport, ~c"::1", port, 5000)
+      assert transport.socket != nil
+
+      assert %Transport{} = transport = Transport.close(transport)
+      assert transport.socket == nil
+    end
   end
 
   describe "is_* macros" do

--- a/test/xandra_test.exs
+++ b/test/xandra_test.exs
@@ -33,6 +33,9 @@ defmodule XandraTest do
       assert_raise ArgumentError, ~r{the :nodes option can't be an empty list}, fn ->
         Xandra.start_link(nodes: [])
       end
+
+      # IPv6 Connection
+      assert {:ok, _conn} = Xandra.start_link(nodes: ["127.0.0.1"], transport_options: [:inet6])
     end
 
     test "validates the :authentication option" do

--- a/test/xandra_test.exs
+++ b/test/xandra_test.exs
@@ -195,6 +195,19 @@ defmodule XandraTest do
 
       assert_received {[:xandra, :failed_to_connect], ^telemetry_ref, %{}, %{connection: ^conn}}
     end
+
+    test "invalid transport option gets forcibly overwritten" do
+      telemetry_ref =
+        :telemetry_test.attach_event_handlers(self(), [[:xandra, :connected]])
+
+      # Set a transport option `active: true` that normally would cause the
+      # connection to fail. This connection should succeed because start_link
+      # forcibly overrides and sets some necessary options.
+      options = Keyword.merge(default_start_options(), transport_options: [active: true])
+
+      conn = start_supervised!({Xandra, options})
+      assert_receive {[:xandra, :connected], ^telemetry_ref, %{}, %{connection: ^conn}}
+    end
   end
 
   describe "execute/3,4" do


### PR DESCRIPTION
Hi there, thanks for the awesome library!

I'm running infrastructure on a platform called fly.io which runs IPv6 private networks.
I was unable to connect to my ScyllaDB cluster using Xandra and found that there were a few limitations to IPv6 support.

This pull request adds proposed fixes for the below 2 issues. I've added some tests and tried to ensure that this change would not break `Xandra.start_link()` and `Xandra.Cluster.start_link()` but there may be other places using these options that I may have missed.

In my fork, I'm now able to establish an IPv6 connection to my cluster and get kicked back due to lack of authentication whereas before connections would hang or hit sync_connection_timeout errors.

```elixir
iex(1)> Xandra.start_link(nodes: ["my-scylla-cluster.internal"], transport_options: [:inet6])     
{:ok, #PID<0.2711.0>}
** (EXIT from #PID<0.2710.0>) shell process exited with reason: an exception was raised:
    ** (RuntimeError) Cassandra server requires authentication but the :authentication option was not provided
        (xandra 0.19.1) lib/xandra/protocol/v4.ex:48: Xandra.Protocol.V4.encode_request/3
        (xandra 0.19.1) lib/xandra/connection/utils.ex:143: Xandra.Connection.Utils.authenticate_connection/5
        (xandra 0.19.1) lib/xandra/connection.ex:458: Xandra.Connection.disconnected/3
        (stdlib 4.3.1.5) gen_statem.erl:1426: :gen_statem.loop_state_callback/11
        (stdlib 4.3.1.5) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

## Cannot specify IPv6 node addresses.

```elixir
iex(1)> Xandra.start_link(nodes: ["::1"])   
** (NimbleOptions.ValidationError) invalid list in :nodes option: invalid value for list element at position 0: invalid node: "::1"
    (nimble_options 1.1.1) lib/nimble_options.ex:359: NimbleOptions.validate!/2
    (xandra 0.19.1) lib/xandra.ex:508: Xandra.start_link/1
    iex:1: (file)
```

## Cannot pass `:inet6` as a transport option for `:gen_tcp`

```elixir
iex(1)> Xandra.start_link(nodes: ["localhost"], transport_options: [:inet6])
** (NimbleOptions.ValidationError) invalid value for :transport_options option: expected keyword list, got: [:inet6]
    (nimble_options 1.1.1) lib/nimble_options.ex:359: NimbleOptions.validate!/2
    (xandra 0.19.1) lib/xandra.ex:508: Xandra.start_link/1
    iex:1: (file)
```

`:gen_tcp` accepts [options](https://www.erlang.org/docs/19/man/gen_tcp#type-option) that are not strictly keywords.

```elixir
iex(2)> :gen_tcp.connect('my-scylla-cluster.internal', 9042, [:inet6])
{:ok, #Port<0.27>}
iex(3)> :gen_tcp.connect('my-scylla-cluster.internal', 9042, [{:inet6, true}])
{:error, :nxdomain}
iex(4)> :gen_tcp.connect('my-scylla-cluster.internal', 9042, [inet6: true])
{:error, :nxdomain}
```
