### PR TITLE
Add token-aware routing to Xandra.Cluster

### DIFF
--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -79,6 +79,16 @@ defmodule Xandra.Cluster do
     * `Xandra.Cluster.LoadBalancingPolicy.DCAwareRoundRobin` - it will execute the
       queries on the nodes in a round robin manner, prioritizing the current DC.
 
+  ## Token-aware Routing
+
+  On top of the load-balancing policy, `Xandra.Cluster` supports **token-aware
+  routing** (see the `:token_aware_routing` option in `start_link/1`). When enabled,
+  executing a *prepared* query whose partition key values are fully bound routes the
+  query to the node that is the primary replica for the query's partition (when Xandra
+  has a connection to it). This saves a network hop between the coordinator node and
+  the replica. Token-aware routing is best-effort and falls back to the load-balancing
+  policy whenever the token cannot be computed or the replica is not connected.
+
   ## Disconnections and Reconnections
 
   `Xandra.Cluster` also supports nodes disconnecting and reconnecting: if Xandra
@@ -98,7 +108,7 @@ defmodule Xandra.Cluster do
   """
 
   alias Xandra.{Batch, ConnectionError, Prepared, RetryStrategy}
-  alias Xandra.Cluster.{ControlConnection, Host, Pool}
+  alias Xandra.Cluster.{ControlConnection, Host, Pool, Token}
 
   @typedoc """
   A Xandra cluster.
@@ -245,6 +255,21 @@ defmodule Xandra.Cluster do
       default: 1,
       doc: """
       The number of connections to open to each node in the cluster. *Available since v0.18.0*.
+      """
+    ],
+    token_aware_routing: [
+      type: :boolean,
+      default: false,
+      doc: """
+      Whether to enable *token-aware routing*. When enabled, executing a prepared query
+      whose partition key values are fully bound routes the query to the node that is the
+      *primary replica* for the query's partition (when Xandra has a connection to it),
+      instead of a node picked by the load-balancing policy alone. This saves a network
+      hop between coordinator and replica for most queries. Token-aware routing is
+      best-effort: if the replica is not connected (or the token cannot be computed, for
+      example for simple queries, batches, or with native protocol v3), the query falls
+      back to the load-balancing policy. Only the Murmur3 partitioner (the default in both
+      Cassandra and ScyllaDB) is supported. *Available since v0.20.0*.
       """
     ],
     debug: [
@@ -433,6 +458,7 @@ defmodule Xandra.Cluster do
     with_conn_and_retrying(
       cluster,
       options,
+      _token = nil,
       fn conn ->
         Xandra.execute(conn, batch, options_without_retry_strategy)
       end
@@ -457,6 +483,7 @@ defmodule Xandra.Cluster do
     with_conn_and_retrying(
       cluster,
       options,
+      routing_token(query, params),
       fn conn ->
         Xandra.execute(conn, query, params, options_without_retry_strategy)
       end
@@ -534,8 +561,8 @@ defmodule Xandra.Cluster do
     Pool.connected_hosts(cluster)
   end
 
-  defp with_conn_and_retrying(cluster, options, fun) when is_function(fun, 1) do
-    case Pool.checkout(cluster) do
+  defp with_conn_and_retrying(cluster, options, token, fun) when is_function(fun, 1) do
+    case Pool.checkout(cluster, token) do
       {:error, :empty} ->
         action = "checkout from cluster #{inspect(cluster)}"
         {:error, ConnectionError.new(action, {:cluster, :not_connected})}
@@ -544,6 +571,20 @@ defmodule Xandra.Cluster do
         RetryStrategy.run_on_cluster(options, connected_hosts, fun)
     end
   end
+
+  # Computes the partition token of the query for token-aware routing. This is
+  # best-effort: for queries where we can't compute the token (simple queries
+  # and batches have no partition key metadata, and native protocol v3 doesn't
+  # return partition key indices), we return nil and routing falls back to the
+  # load-balancing policy.
+  defp routing_token(%Prepared{} = prepared, params) do
+    case Token.compute(prepared, params) do
+      {:ok, token} -> token
+      :error -> nil
+    end
+  end
+
+  defp routing_token(_query, _params), do: nil
 
   defp with_conn(cluster, fun) do
     case Pool.checkout(cluster) do

--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -9,7 +9,7 @@ defmodule Xandra.Cluster.Pool do
 
   @behaviour :gen_statem
 
-  alias Xandra.Cluster.{ConnectionPool, Host, LoadBalancingPolicy}
+  alias Xandra.Cluster.{ConnectionPool, Host, LoadBalancingPolicy, TokenRing}
   alias Xandra.GenStatemHelpers
 
   require Record
@@ -52,10 +52,12 @@ defmodule Xandra.Cluster.Pool do
     :gen_statem.stop(pid, reason, timeout)
   end
 
-  @spec checkout(:gen_statem.server_ref()) ::
+  # `token` is the partition token of the query being executed (if it could be
+  # computed), used for token-aware routing.
+  @spec checkout(:gen_statem.server_ref(), integer() | nil) ::
           {:ok, [{pid(), Host.t()}, ...]} | {:error, :empty}
-  def checkout(pid) do
-    :gen_statem.call(pid, :checkout)
+  def checkout(pid, token \\ nil) when is_integer(token) or is_nil(token) do
+    :gen_statem.call(pid, {:checkout, token})
   end
 
   @spec connected_hosts(:gen_statem.server_ref()) :: [Host.t()]
@@ -96,6 +98,16 @@ defmodule Xandra.Cluster.Pool do
 
     # The number of connections in each pool to a node.
     :pool_size,
+
+    # Whether to enable token-aware routing.
+    :token_aware_routing,
+
+    # The ring of tokens of the cluster ({token, peername} entries sorted in a
+    # tuple), or nil if token-aware routing is off or the ring is unknown.
+    :token_ring,
+
+    # The partitioner used by the cluster, as reported in system.local.
+    :partitioner,
 
     # Erlang alias to send back the ":connected" message to make :sync_connect work.
     # This is nil if :sync_connect was not used.
@@ -161,6 +173,7 @@ defmodule Xandra.Cluster.Pool do
       target_pools: Keyword.fetch!(cluster_opts, :target_pools),
       name: Keyword.get(cluster_opts, :name),
       pool_size: Keyword.fetch!(cluster_opts, :pool_size),
+      token_aware_routing: Keyword.fetch!(cluster_opts, :token_aware_routing),
       pool_supervisor: pool_sup,
       refresh_topology_interval: Keyword.fetch!(cluster_opts, :refresh_topology_interval),
       checkout_queue: checkout_queue(queue: :queue.new(), max_size: checkout_queue_max_size),
@@ -198,17 +211,25 @@ defmodule Xandra.Cluster.Pool do
 
   def handle_event({:timeout, :flush_checkout_queue}, nil, :never_connected, %__MODULE__{} = data) do
     {checkout_queue(queue: queue), data} = get_and_update_in(data.checkout_queue, &{&1, nil})
-    reply_actions = for from <- :queue.to_list(queue), do: {:reply, from, {:error, :empty}}
+
+    reply_actions =
+      for {from, _token} <- :queue.to_list(queue), do: {:reply, from, {:error, :empty}}
+
     {:keep_state, data, reply_actions}
   end
 
   # We have never connected, but we already flushed once, so we won't keep adding requests to
   # the queue.
-  def handle_event({:call, from}, :checkout, :never_connected, %__MODULE__{checkout_queue: nil}) do
+  def handle_event(
+        {:call, from},
+        {:checkout, _token},
+        :never_connected,
+        %__MODULE__{checkout_queue: nil}
+      ) do
     {:keep_state_and_data, {:reply, from, {:error, :empty}}}
   end
 
-  def handle_event({:call, from}, :checkout, :never_connected, %__MODULE__{} = data) do
+  def handle_event({:call, from}, {:checkout, token}, :never_connected, %__MODULE__{} = data) do
     checkout_queue(queue: queue, max_size: max_size) = data.checkout_queue
 
     if :queue.len(queue) == max_size do
@@ -217,15 +238,15 @@ defmodule Xandra.Cluster.Pool do
       data =
         put_in(
           data.checkout_queue,
-          checkout_queue(data.checkout_queue, queue: :queue.in(from, queue))
+          checkout_queue(data.checkout_queue, queue: :queue.in({from, token}, queue))
         )
 
       {:keep_state, data}
     end
   end
 
-  def handle_event({:call, from}, :checkout, :has_connected_once, %__MODULE__{} = data) do
-    {data, reply_action} = checkout_connection(data, from)
+  def handle_event({:call, from}, {:checkout, token}, :has_connected_once, %__MODULE__{} = data) do
+    {data, reply_action} = checkout_connection(data, from, token)
     {:keep_state, data, reply_action}
   end
 
@@ -292,6 +313,19 @@ defmodule Xandra.Cluster.Pool do
         handle_host_added(data_acc, Map.fetch!(new_peers_map, peername))
       end)
 
+    # For the peers that we already knew about, refresh their info (their
+    # tokens could change, for example), so that the token ring stays accurate.
+    data =
+      update_in(data.peers, fn peers ->
+        Map.new(peers, fn {peername, info} ->
+          case Map.fetch(new_peers_map, peername) do
+            {:ok, %Host{} = new_host} -> {peername, %{info | host: new_host}}
+            :error -> {peername, info}
+          end
+        end)
+      end)
+
+    data = update_token_ring(data)
     data = maybe_start_pools(data)
     {:keep_state, data}
   end
@@ -405,11 +439,18 @@ defmodule Xandra.Cluster.Pool do
 
   ## Helpers
 
-  defp checkout_connection(data, from) do
+  defp checkout_connection(data, from, token) do
+    # Only use the query's token when token-aware routing is enabled, so that
+    # (with the default configuration) nothing changes in how queries are
+    # distributed over nodes and connections.
+    token = if data.token_aware_routing, do: token
+
     {query_plan, data} =
       get_and_update_in(data.load_balancing_state, fn lb_state ->
         data.load_balancing_module.query_plan(lb_state)
       end)
+
+    query_plan = maybe_prioritize_token_owner(data, query_plan, token)
 
     # Find all connected hosts
     connected_hosts =
@@ -427,6 +468,44 @@ defmodule Xandra.Cluster.Pool do
       end
 
     {data, {:reply, from, reply}}
+  end
+
+  # With token-aware routing, move the host that is the primary replica for the
+  # query's token to the front of the query plan, so that (when we have a
+  # connection to it) the query is executed on a replica that owns the data.
+  defp maybe_prioritize_token_owner(%__MODULE__{token_ring: ring}, query_plan, token)
+       when is_nil(ring) or is_nil(token) do
+    query_plan
+  end
+
+  defp maybe_prioritize_token_owner(%__MODULE__{token_ring: ring}, query_plan, token) do
+    owner_peername = TokenRing.owner_peername(ring, token)
+
+    case Enum.split_with(query_plan, &(Host.to_peername(&1) == owner_peername)) do
+      {[], _query_plan} -> query_plan
+      {owners, rest} -> owners ++ rest
+    end
+  end
+
+  # Rebuilds the token ring from the current set of peers. We only support
+  # token-aware routing with the Murmur3 partitioner (the default in both
+  # Cassandra and ScyllaDB, and the only one ScyllaDB supports).
+  defp update_token_ring(%__MODULE__{token_aware_routing: false} = data), do: data
+
+  defp update_token_ring(%__MODULE__{} = data) do
+    hosts = for {_peername, %{host: %Host{} = host}} <- data.peers, do: host
+
+    partitioner =
+      Enum.find_value(hosts, data.partitioner, fn %Host{partitioner: partitioner} ->
+        partitioner
+      end)
+
+    token_ring =
+      if is_binary(partitioner) and String.ends_with?(partitioner, "Murmur3Partitioner") do
+        TokenRing.build(hosts)
+      end
+
+    %__MODULE__{data | partitioner: partitioner, token_ring: token_ring}
   end
 
   defp handle_host_added(%__MODULE__{} = data, %Host{} = host) do
@@ -633,8 +712,8 @@ defmodule Xandra.Cluster.Pool do
     {checkout_queue(queue: queue), data} = get_and_update_in(data.checkout_queue, &{&1, nil})
 
     {reply_actions, data} =
-      Enum.map_reduce(:queue.to_list(queue), data, fn from, data ->
-        {data, reply_action} = checkout_connection(data, from)
+      Enum.map_reduce(:queue.to_list(queue), data, fn {from, token}, data ->
+        {data, reply_action} = checkout_connection(data, from, token)
         {reply_action, data}
       end)
 

--- a/test/integration/errors_test.exs
+++ b/test/integration/errors_test.exs
@@ -86,7 +86,7 @@ defmodule ErrorsTest do
         :state_functions
       end
 
-      def waiting({:call, from}, :checkout, data) do
+      def waiting({:call, from}, {:checkout, _token}, data) do
         {:keep_state_and_data, {:reply, from, {:ok, data}}}
       end
     end


### PR DESCRIPTION
PR 3 of 4 towards ScyllaDB shard awareness (#324): keep partition key metadata → token/ring modules → **token-aware routing** → shard awareness.

New `token_aware_routing: boolean()` option for `Xandra.Cluster.start_link/1`, **defaulting to `false`** (zero behavior change unless opted in). When enabled:

- `Xandra.Cluster.execute/3,4` computes the partition token for prepared queries whose partition key values are fully bound.
- `Xandra.Cluster.Pool` maintains the token ring (rebuilt on topology refresh, including refreshing known hosts whose token sets change) and moves the primary-replica host to the front of the load-balancing query plan when it owns the query's token.

Executing a query on a replica that owns the partition saves the coordinator→replica network hop. This is the standard "TokenAwarePolicy" behavior of the Java/Python/Go drivers, and the prerequisite for ScyllaDB shard awareness (next PR). It's strictly best-effort: simple statements, batches, protocol v3, non-Murmur3 partitioners, missing values, or a disconnected replica all fall back to the plain load-balancing policy.

