### PR TITLE
Add ScyllaDB shard awareness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,12 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # Each ScyllaDB shard reserves Async I/O request capacity, and with the
+      # multi-shard scylladb_shard_aware service the kernel's default limit is
+      # not enough for all the ScyllaDB containers to boot.
+      - name: Increase the Async I/O capacity for ScyllaDB
+        run: sudo sysctl -w fs.aio-max-nr=1048576
+
       - name: Start Docker and wait for it to be up
         run: |
           docker compose up --detach --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,32 @@ services:
       options:
         max-size: 50m
 
+  # A multi-shard ScyllaDB instance to test shard awareness, with the
+  # shard-aware port (19042) exposed. The shard-aware port must be mapped to
+  # the same port on the host, because ScyllaDB advertises its own (internal)
+  # port number to clients.
+  scylladb_shard_aware:
+    build:
+      context: ./test/docker
+      dockerfile: scylladb.dockerfile
+      args:
+        SCYLLA_VERSION: ${SCYLLA_VERSION:-5.2}
+    ports:
+      - "9072:9042"
+      - "19042:19042"
+    command:
+      - "--smp"
+      - "2"
+    healthcheck:
+      test: [ "CMD-SHELL", "nodetool -h ::FFFF:127.0.0.1 status" ]
+      interval: 20s
+      timeout: 10s
+      retries: 12
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 50m
+
   scylladb_with_auth:
     build:
       context: ./test/docker

--- a/lib/xandra.ex
+++ b/lib/xandra.ex
@@ -458,7 +458,13 @@ defmodule Xandra do
     ],
 
     # Internal options, used by Xandra.Cluster.
-    cluster_pid: [doc: false, type: :pid]
+    cluster_pid: [doc: false, type: :pid],
+    # PID to send ScyllaDB sharding info (parsed from the SUPPORTED options) to
+    # after each successful connection.
+    sharding_info_pid: [doc: false, type: :pid],
+    # When set, connect to this ScyllaDB shard through the shard-aware port:
+    # %{shard: ..., nr_shards: ..., port: ...}.
+    shard_target: [doc: false, type: :map]
   ]
 
   @typedoc "Options for `start_link/1`."

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -79,7 +79,7 @@ defmodule Xandra.Cluster do
     * `Xandra.Cluster.LoadBalancingPolicy.DCAwareRoundRobin` - it will execute the
       queries on the nodes in a round robin manner, prioritizing the current DC.
 
-  ## Token-aware Routing
+  ## Token-aware Routing and ScyllaDB Shard Awareness
 
   On top of the load-balancing policy, `Xandra.Cluster` supports **token-aware
   routing** (see the `:token_aware_routing` option in `start_link/1`). When enabled,
@@ -88,6 +88,16 @@ defmodule Xandra.Cluster do
   has a connection to it). This saves a network hop between the coordinator node and
   the replica. Token-aware routing is best-effort and falls back to the load-balancing
   policy whenever the token cannot be computed or the replica is not connected.
+
+  When connected to [ScyllaDB](https://www.scylladb.com), Xandra additionally supports
+  **shard awareness** (see the `:shard_awareness` option in `start_link/1`). ScyllaDB
+  shards data *per CPU core* within each node. With shard awareness enabled, Xandra
+  maintains at least one connection per shard to each node, and (combined with
+  token-aware routing) executes each query on a connection to the exact CPU core
+  that owns the queried partition. For this to work, ScyllaDB's *shard-aware port*
+  (`19042` by default, `19142` for TLS) must be reachable, and the network path must
+  not rewrite TCP source ports (as NAT often does): Xandra detects both conditions
+  and falls back to regular connections when they're not met.
 
   ## Disconnections and Reconnections
 
@@ -270,6 +280,22 @@ defmodule Xandra.Cluster do
       example for simple queries, batches, or with native protocol v3), the query falls
       back to the load-balancing policy. Only the Murmur3 partitioner (the default in both
       Cassandra and ScyllaDB) is supported. *Available since v0.20.0*.
+      """
+    ],
+    shard_awareness: [
+      type: :boolean,
+      default: false,
+      doc: """
+      Whether to enable *shard awareness* for ScyllaDB clusters. ScyllaDB shards data
+      per CPU core within each node. When this option is enabled and Xandra detects that
+      it's connected to ScyllaDB, it maintains at least one connection *per shard* to each
+      node (by connecting through [ScyllaDB's shard-aware
+      port](https://github.com/scylladb/scylladb/blob/master/docs/dev/protocol-extensions.md#intranode-sharding), which
+      must be reachable, `19042` by default). Combined with `:token_aware_routing`, this
+      routes each query directly to the CPU core that owns the data, skipping cross-shard
+      hops. This option has no effect when connecting to Cassandra, and it's best-effort:
+      if the shard-aware port is not reachable or source ports get rewritten by NAT,
+      Xandra falls back to the regular pool behavior. *Available since v0.20.0*.
       """
     ],
     debug: [

--- a/lib/xandra/cluster/connection_pool.ex
+++ b/lib/xandra/cluster/connection_pool.ex
@@ -1,34 +1,71 @@
 defmodule Xandra.Cluster.ConnectionPool do
   @moduledoc false
 
+  # A pool of Xandra connections to a single host. The pool is a supervisor with
+  # two children:
+  #
+  #   * a ShardManager, which tracks which ScyllaDB shard each connection is on
+  #     (and directs opening connections to specific shards, see the docs in
+  #     that module);
+  #
+  #   * a plain supervisor for the connections themselves, which starts *empty*:
+  #     the ShardManager populates it, so that the connection specs can point at
+  #     the current ShardManager process.
+  #
+  # The strategy is :one_for_all: if the ShardManager crashes, the connections
+  # are restarted with it, so a fresh ShardManager always (re)builds its view of
+  # the connections from scratch and can never go out of sync. If connections
+  # keep crashing, first the connections supervisor and then this supervisor
+  # give up, and the cluster reacts by marking the host and eventually
+  # restarting the whole pool.
+  #
+  # Checking out a connection accepts an optional partition token: when the pool
+  # knows the sharding parameters of the host (ScyllaDB only), it hands out a
+  # connection to the shard that owns the token, falling back to a random
+  # connection otherwise.
+
   use Supervisor
+
+  alias Xandra.Cluster.ConnectionPool.ShardManager
 
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) when is_list(opts) do
     connection_opts = Keyword.fetch!(opts, :connection_options)
     pool_size = Keyword.fetch!(opts, :pool_size)
-    Supervisor.start_link(__MODULE__, {connection_opts, pool_size})
+    shard_awareness? = Keyword.get(opts, :shard_awareness, false)
+    Supervisor.start_link(__MODULE__, {connection_opts, pool_size, shard_awareness?})
   end
 
-  @spec checkout(pid()) :: pid()
-  def checkout(sup_pid) when is_pid(sup_pid) do
-    pids =
-      for {_id, pid, _type, _modules} when is_pid(pid) <- Supervisor.which_children(sup_pid) do
-        pid
-      end
+  # Checks out a connection from the pool. If token is an integer and the pool
+  # knows the sharding parameters of the host, returns a connection to the shard
+  # that owns the token (if there is one). Returns nil if the pool is shutting
+  # down or has no connections.
+  @spec checkout(pid(), integer() | nil) :: pid() | nil
+  def checkout(sup_pid, token \\ nil) when is_pid(sup_pid) do
+    case List.keyfind(Supervisor.which_children(sup_pid), ShardManager, 0) do
+      {ShardManager, manager_pid, _type, _modules} when is_pid(manager_pid) ->
+        ShardManager.checkout(manager_pid, token)
 
-    Enum.random(pids)
+      _other ->
+        nil
+    end
+  catch
+    :exit, _reason -> nil
   end
 
   ## Callbacks
 
   @impl true
-  def init({connection_opts, pool_size}) do
-    children =
-      for index <- 1..pool_size do
-        Supervisor.child_spec({Xandra, connection_opts}, id: {Xandra, index})
-      end
+  def init({connection_opts, pool_size, shard_awareness?}) do
+    children = [
+      {ShardManager, {self(), connection_opts, pool_size, shard_awareness?}},
+      %{
+        id: :connections_supervisor,
+        start: {Supervisor, :start_link, [[], [strategy: :one_for_one]]},
+        type: :supervisor
+      }
+    ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_all)
   end
 end

--- a/lib/xandra/cluster/connection_pool/shard_manager.ex
+++ b/lib/xandra/cluster/connection_pool/shard_manager.ex
@@ -1,0 +1,359 @@
+defmodule Xandra.Cluster.ConnectionPool.ShardManager do
+  @moduledoc false
+
+  # The "brain" of a Xandra.Cluster.ConnectionPool. This process holds no
+  # connections itself: it starts them under the pool's connections supervisor
+  # (its sibling) and only *monitors* them, so that all process lifecycle
+  # (restarts, shutdown ordering, and so on) stays with the supervision tree.
+  #
+  # Its jobs are:
+  #
+  #   * starting the initial :pool_size connections to the host's regular CQL
+  #     port;
+  #
+  #   * tracking which ScyllaDB shard each connection lands on (connections
+  #     report the sharding info they find in the SUPPORTED message after every
+  #     successful handshake);
+  #
+  #   * when connected to ScyllaDB with the :shard_awareness cluster option
+  #     enabled, making sure that every shard of the host has at least one
+  #     connection. Missing shards are targeted deterministically by connecting
+  #     to ScyllaDB's *shard-aware port*: on that port, ScyllaDB assigns the
+  #     connection to the shard equal to the connection's *source port* modulo
+  #     the number of shards;
+  #
+  #   * handing out the connection on the shard that owns a query's partition
+  #     token on checkout.
+
+  use GenServer
+
+  alias Xandra.Cluster.Token
+
+  # How many times a shard-targeted connection can fail to connect (for example,
+  # because the shard-aware port is blocked by a firewall or NAT) before we give
+  # up on shard-aware connections for this host and fall back to the plain pool.
+  @max_shard_aware_connect_failures 3
+
+  defstruct [
+    :parent_supervisor,
+    :connections_supervisor,
+    :connection_options,
+    :pool_size,
+    :shard_awareness?,
+    :encryption?,
+
+    # The latest sharding info reported by any connection to this host, or nil
+    # if unknown (not connected yet, or not ScyllaDB).
+    # %{shard: ..., nr_shards: ..., sharding_ignore_msb: ..., shard_aware_port: ...,
+    #   shard_aware_port_ssl: ...}
+    :sharding_info,
+
+    # Set to true when we give up on connecting through the shard-aware port.
+    shard_aware_disabled?: false,
+
+    # conn pid => %{shard: non_neg_integer() | nil, target_shard: non_neg_integer() | nil,
+    #               connected?: boolean(), connect_failures: non_neg_integer()}
+    connections: %{}
+  ]
+
+  ## Public API
+
+  @spec start_link({pid(), keyword(), pos_integer(), boolean()}) :: GenServer.on_start()
+  def start_link({parent_sup, connection_opts, pool_size, shard_awareness?}) do
+    GenServer.start_link(__MODULE__, {parent_sup, connection_opts, pool_size, shard_awareness?})
+  end
+
+  @spec checkout(pid(), integer() | nil) :: pid() | nil
+  def checkout(manager_pid, token) when is_pid(manager_pid) do
+    GenServer.call(manager_pid, {:checkout, token})
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init({parent_sup, connection_opts, pool_size, shard_awareness?}) do
+    state = %__MODULE__{
+      parent_supervisor: parent_sup,
+      connection_options: Keyword.put(connection_opts, :sharding_info_pid, self()),
+      pool_size: pool_size,
+      shard_awareness?: shard_awareness?,
+      encryption?: Keyword.get(connection_opts, :encryption, false)
+    }
+
+    {:ok, state, {:continue, :start_initial_connections}}
+  end
+
+  @impl true
+  def handle_continue(:start_initial_connections, %__MODULE__{} = state) do
+    # This blocks until the parent supervisor is done starting its children,
+    # which guarantees that the connections supervisor is there.
+    {:connections_supervisor, connections_sup, _type, _modules} =
+      state.parent_supervisor
+      |> Supervisor.which_children()
+      |> List.keyfind(:connections_supervisor, 0)
+
+    state = %__MODULE__{state | connections_supervisor: connections_sup}
+
+    state =
+      Enum.reduce(1..state.pool_size, state, fn index, state_acc ->
+        spec = Supervisor.child_spec({Xandra, state_acc.connection_options}, id: {Xandra, index})
+        start_connection(state_acc, spec, _target_shard = nil)
+      end)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call({:checkout, token}, _from, %__MODULE__{} = state) do
+    {:reply, pick_connection(state, token), state}
+  end
+
+  @impl true
+  def handle_info(message, state)
+
+  def handle_info({:xandra, :sharding_info, conn_pid, sharding_info}, %__MODULE__{} = state) do
+    state = register_connection_if_unknown(state, conn_pid)
+
+    state =
+      case state.connections do
+        %{^conn_pid => conn_info} ->
+          shard = if sharding_info, do: sharding_info.shard
+
+          # Sharding info is reported right after a successful handshake, so
+          # this connection is connected.
+          state =
+            put_in(state.connections[conn_pid], %{conn_info | shard: shard, connected?: true})
+
+          state = if sharding_info, do: %{state | sharding_info: sharding_info}, else: state
+
+          if not is_nil(conn_info.target_shard) and shard != conn_info.target_shard do
+            # A connection through the shard-aware port landed on a different
+            # shard than the one we targeted: something (like NAT) is rewriting
+            # source ports, so targeting shards cannot work. Give up on it to
+            # avoid opening more and more connections that miss their target.
+            disable_shard_awareness(state)
+          else
+            maybe_fill_shards(state)
+          end
+
+        _other ->
+          state
+      end
+
+    {:noreply, state}
+  end
+
+  # Sent by shard-targeted connections (which have this manager as their
+  # :cluster_pid): count consecutive connection failures, and give up on the
+  # shard-aware port for this host if a connection keeps failing.
+  def handle_info({:xandra, :failed_to_connect, _peername, conn_pid}, %__MODULE__{} = state) do
+    # The connection can be a supervisor-restarted one that we don't know yet:
+    # if it *never* manages to connect, this message is the only one it will
+    # ever send us, so we must register it here or its failures would not count
+    # towards giving up on the shard-aware port.
+    state = register_connection_if_unknown(state, conn_pid)
+
+    case state.connections do
+      %{^conn_pid => %{target_shard: target_shard} = conn_info}
+      when not is_nil(target_shard) ->
+        failures = conn_info.connect_failures + 1
+
+        if failures >= @max_shard_aware_connect_failures do
+          {:noreply, disable_shard_awareness(state)}
+        else
+          {:noreply, put_in(state.connections[conn_pid].connect_failures, failures)}
+        end
+
+      _other ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:xandra, :connected, _peername, conn_pid}, %__MODULE__{} = state) do
+    state =
+      case state.connections do
+        %{^conn_pid => conn_info} ->
+          put_in(state.connections[conn_pid], %{conn_info | connected?: true, connect_failures: 0})
+
+        _other ->
+          state
+      end
+
+    {:noreply, state}
+  end
+
+  # We must not hand out disconnected connections on checkout: connections
+  # reconnect on their own with backoff, but until they do, queries would fail
+  # even when other connections to the host are healthy.
+  def handle_info({:xandra, :disconnected, _peername, conn_pid}, %__MODULE__{} = state) do
+    state =
+      case state.connections do
+        %{^conn_pid => conn_info} ->
+          put_in(state.connections[conn_pid], %{conn_info | connected?: false})
+
+        _other ->
+          state
+      end
+
+    {:noreply, state}
+  end
+
+  # A connection died. Its supervisor takes care of restarting it (the new
+  # process will report its sharding info once it connects), so we only need to
+  # forget the old PID.
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, %__MODULE__{} = state) do
+    state = update_in(state.connections, &Map.delete(&1, pid))
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  ## Helpers
+
+  defp start_connection(%__MODULE__{} = state, spec, target_shard) do
+    case Supervisor.start_child(state.connections_supervisor, spec) do
+      {:ok, conn_pid} ->
+        track_connection(state, conn_pid, target_shard)
+
+      {:error, {:already_started, conn_pid}} ->
+        track_connection(state, conn_pid, target_shard)
+
+      # The spec is there but its connection is not running: revive it.
+      {:error, :already_present} ->
+        case Supervisor.restart_child(state.connections_supervisor, spec.id) do
+          {:ok, conn_pid} -> track_connection(state, conn_pid, target_shard)
+          {:error, _reason} -> state
+        end
+    end
+  end
+
+  defp track_connection(%__MODULE__{} = state, conn_pid, target_shard) do
+    if Map.has_key?(state.connections, conn_pid) do
+      state
+    else
+      Process.monitor(conn_pid)
+
+      put_in(
+        state.connections[conn_pid],
+        %{shard: nil, target_shard: target_shard, connected?: false, connect_failures: 0}
+      )
+    end
+  end
+
+  # Registers a connection that we don't know yet, which happens when a
+  # connection crashes and its supervisor restarts it: the new process reports
+  # its sharding info, but we only know the old PID. The connection's child ID
+  # in the supervisor tells us whether it targets a specific shard.
+  defp register_connection_if_unknown(%__MODULE__{} = state, conn_pid) do
+    if Map.has_key?(state.connections, conn_pid) do
+      state
+    else
+      child_id =
+        state.connections_supervisor
+        |> Supervisor.which_children()
+        |> Enum.find_value(fn {id, pid, _type, _modules} -> if pid == conn_pid, do: id end)
+
+      case child_id do
+        {Xandra, _index} -> track_connection(state, conn_pid, _target_shard = nil)
+        {:shard, target_shard} -> track_connection(state, conn_pid, target_shard)
+        # Not one of our connections (or already gone): ignore it.
+        nil -> state
+      end
+    end
+  end
+
+  defp maybe_fill_shards(%__MODULE__{shard_awareness?: false} = state), do: state
+  defp maybe_fill_shards(%__MODULE__{shard_aware_disabled?: true} = state), do: state
+  defp maybe_fill_shards(%__MODULE__{sharding_info: nil} = state), do: state
+
+  defp maybe_fill_shards(%__MODULE__{sharding_info: %{nr_shards: nr_shards}} = state) do
+    if shard_aware_port(state) do
+      covered_shards =
+        for {_pid, %{shard: shard, target_shard: target_shard}} <- state.connections,
+            covered = shard || target_shard,
+            into: MapSet.new(),
+            do: covered
+
+      Enum.reduce(0..(nr_shards - 1), state, fn shard, state_acc ->
+        if MapSet.member?(covered_shards, shard) do
+          state_acc
+        else
+          start_connection(state_acc, shard_targeted_spec(state_acc, shard), shard)
+        end
+      end)
+    else
+      # Old ScyllaDB without a shard-aware port: we cannot target shards.
+      disable_shard_awareness(state)
+    end
+  end
+
+  defp shard_targeted_spec(%__MODULE__{} = state, shard) do
+    # Shard-targeted connections report to this manager instead of the cluster:
+    # their failures don't mean that the host is down, and their peername
+    # (host + shard-aware port) is unknown to the cluster.
+    options =
+      state.connection_options
+      |> Keyword.put(:cluster_pid, self())
+      |> Keyword.put(:shard_target, %{
+        shard: shard,
+        nr_shards: state.sharding_info.nr_shards,
+        port: shard_aware_port(state)
+      })
+
+    Supervisor.child_spec({Xandra, options}, id: {:shard, shard})
+  end
+
+  defp disable_shard_awareness(%__MODULE__{} = state) do
+    state = %{state | shard_aware_disabled?: true}
+
+    # Terminate and remove all shard-targeted connections through the
+    # supervisor, so that shutdown semantics stay in supervision land.
+    for {child_id = {:shard, _shard}, _pid, _type, _modules} <-
+          Supervisor.which_children(state.connections_supervisor) do
+      _ = Supervisor.terminate_child(state.connections_supervisor, child_id)
+      _ = Supervisor.delete_child(state.connections_supervisor, child_id)
+    end
+
+    # The monitors of the terminated connections will fire and clean these up
+    # anyway, but let's not hold on to dead PIDs in the meantime.
+    update_in(state.connections, fn connections ->
+      for {pid, conn_info} <- connections,
+          is_nil(conn_info.target_shard),
+          into: %{},
+          do: {pid, conn_info}
+    end)
+  end
+
+  defp shard_aware_port(%__MODULE__{sharding_info: sharding_info} = state) do
+    if state.encryption? do
+      sharding_info.shard_aware_port_ssl
+    else
+      sharding_info.shard_aware_port
+    end
+  end
+
+  defp pick_connection(%__MODULE__{} = state, token) do
+    # Only ever hand out connections that are currently connected: connections
+    # are tracked from before their first handshake and stay tracked while they
+    # reconnect with backoff, but they can't execute queries in the meantime.
+    case for({pid, %{connected?: true} = conn_info} <- state.connections, do: {pid, conn_info}) do
+      [] ->
+        nil
+
+      connected_connections ->
+        with true <- is_integer(token),
+             %{nr_shards: nr_shards, sharding_ignore_msb: ignore_msb} <- state.sharding_info,
+             shard = Token.shard(token, nr_shards, ignore_msb),
+             [_ | _] = candidates <-
+               for({pid, %{shard: ^shard}} <- connected_connections, do: pid) do
+          Enum.random(candidates)
+        else
+          _fallback ->
+            {pid, _conn_info} = Enum.random(connected_connections)
+            pid
+        end
+    end
+  end
+end

--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -99,8 +99,9 @@ defmodule Xandra.Cluster.Pool do
     # The number of connections in each pool to a node.
     :pool_size,
 
-    # Whether to enable token-aware routing.
+    # Whether to enable token-aware routing and ScyllaDB shard awareness.
     :token_aware_routing,
+    :shard_awareness,
 
     # The ring of tokens of the cluster ({token, peername} entries sorted in a
     # tuple), or nil if token-aware routing is off or the ring is unknown.
@@ -174,6 +175,7 @@ defmodule Xandra.Cluster.Pool do
       name: Keyword.get(cluster_opts, :name),
       pool_size: Keyword.fetch!(cluster_opts, :pool_size),
       token_aware_routing: Keyword.fetch!(cluster_opts, :token_aware_routing),
+      shard_awareness: Keyword.fetch!(cluster_opts, :shard_awareness),
       pool_supervisor: pool_sup,
       refresh_topology_interval: Keyword.fetch!(cluster_opts, :refresh_topology_interval),
       checkout_queue: checkout_queue(queue: :queue.new(), max_size: checkout_queue_max_size),
@@ -458,7 +460,7 @@ defmodule Xandra.Cluster.Pool do
           %{pool_pid: pool_pid, host: host} = Map.get(data.peers, Host.to_peername(host)),
           not is_nil(host),
           is_pid(pool_pid) and Process.alive?(pool_pid),
-          pid = ConnectionPool.checkout(pool_pid),
+          pid = ConnectionPool.checkout(pool_pid, token),
           do: {pid, host}
 
     reply =
@@ -552,7 +554,10 @@ defmodule Xandra.Cluster.Pool do
 
     pool_spec =
       Supervisor.child_spec(
-        {data.xandra_mod, connection_options: conn_options, pool_size: data.pool_size},
+        {data.xandra_mod,
+         connection_options: conn_options,
+         pool_size: data.pool_size,
+         shard_awareness: data.shard_awareness},
         id: peername,
         restart: :transient
       )

--- a/lib/xandra/connection.ex
+++ b/lib/xandra/connection.ex
@@ -395,6 +395,8 @@ defmodule Xandra.Connection do
       send(data.cluster_pid, {:xandra, :disconnected, data.peername, self()})
     end
 
+    notify_sharding_info_pid(data, {:xandra, :disconnected, data.peername, self()})
+
     Enum.each(data.in_flight_requests, fn {_stream_id, req_alias} ->
       send_reply(req_alias, {:error, :disconnected})
     end)
@@ -432,6 +434,11 @@ defmodule Xandra.Connection do
     # Now, build the state from the options.
     {address, port} = Keyword.fetch!(options, :node)
 
+    # When targeting a specific ScyllaDB shard, we connect to the host's
+    # shard-aware port instead of the regular CQL port.
+    shard_target = Keyword.get(options, :shard_target)
+    port = if shard_target, do: shard_target.port, else: port
+
     transport = %Transport{
       module: if(options[:encryption], do: :ssl, else: :gen_tcp),
       options:
@@ -459,7 +466,13 @@ defmodule Xandra.Connection do
             Backoff.new(Keyword.take(options, [:backoff_type, :backoff_min, :backoff_max]))
     }
 
-    case Transport.connect(transport, String.to_charlist(address), port, data.connect_timeout) do
+    case connect_transport(
+           transport,
+           String.to_charlist(address),
+           port,
+           data.connect_timeout,
+           shard_target
+         ) do
       {:ok, transport} ->
         {:ok, peername} = Transport.address_and_port(transport)
         data = %__MODULE__{data | transport: transport, peername: peername}
@@ -486,6 +499,13 @@ defmodule Xandra.Connection do
 
           if data.cluster_pid do
             send(data.cluster_pid, {:xandra, :connected, data.peername, self()})
+          end
+
+          notify_sharding_info_pid(data, {:xandra, :connected, data.peername, self()})
+
+          if sharding_info_pid = Keyword.get(data.options, :sharding_info_pid) do
+            sharding_info = Utils.parse_scylla_sharding_info(supported_options)
+            send(sharding_info_pid, {:xandra, :sharding_info, self(), sharding_info})
           end
 
           {:next_state, :connected, data}
@@ -715,6 +735,47 @@ defmodule Xandra.Connection do
 
   ## Helpers
 
+  # How many local source ports we try to bind to when targeting a ScyllaDB
+  # shard, before giving up on the connection attempt.
+  @shard_aware_source_port_attempts 20
+
+  # The IANA ephemeral port range, which is also what other ScyllaDB drivers
+  # use for the local source ports of shard-aware connections.
+  @ephemeral_port_range 49_152..65_535
+
+  defp connect_transport(%Transport{} = transport, address, port, timeout, nil = _shard_target) do
+    Transport.connect(transport, address, port, timeout)
+  end
+
+  # When connecting to ScyllaDB's shard-aware port, the server assigns the
+  # connection to the shard equal to our *source port* modulo the number of
+  # shards, so we bind the socket to a local port that targets the shard we
+  # want. We start from a random port (that is congruent to the shard modulo the
+  # number of shards) in the ephemeral range and step by the number of shards on
+  # EADDRINUSE, wrapping around at the end of the range.
+  defp connect_transport(%Transport{} = transport, address, port, timeout, %{
+         shard: shard,
+         nr_shards: nr_shards
+       }) do
+    first_port =
+      @ephemeral_port_range.first + Integer.mod(shard - @ephemeral_port_range.first, nr_shards)
+
+    candidate_count = div(@ephemeral_port_range.last - first_port, nr_shards) + 1
+    start_index = Enum.random(0..(candidate_count - 1))
+    attempts = min(@shard_aware_source_port_attempts, candidate_count)
+
+    Enum.reduce_while(0..(attempts - 1), {:error, :eaddrinuse}, fn attempt, _last_error ->
+      source_port = first_port + Integer.mod(start_index + attempt, candidate_count) * nr_shards
+      transport_with_port = update_in(transport.options, &(&1 ++ [port: source_port]))
+
+      case Transport.connect(transport_with_port, address, port, timeout) do
+        {:ok, transport} -> {:halt, {:ok, transport}}
+        {:error, :eaddrinuse} -> {:cont, {:error, :eaddrinuse}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
   defp startup_connection(
          %Transport{} = transport,
          supported_options,
@@ -758,6 +819,20 @@ defmodule Xandra.Connection do
         options
       )
     end
+  end
+
+  # Forwards connection lifecycle messages to the pool that tracks sharding
+  # info (if there is one), which needs to know whether connections are usable.
+  # When the connection targets a specific shard, its :cluster_pid *is* that
+  # pool, so we avoid sending the message twice.
+  defp notify_sharding_info_pid(%__MODULE__{} = data, message) do
+    sharding_info_pid = Keyword.get(data.options, :sharding_info_pid)
+
+    if is_pid(sharding_info_pid) and sharding_info_pid != data.cluster_pid do
+      send(sharding_info_pid, message)
+    end
+
+    :ok
   end
 
   defp disconnect(%__MODULE__{} = data, reason) do

--- a/lib/xandra/connection/utils.ex
+++ b/lib/xandra/connection/utils.ex
@@ -80,6 +80,39 @@ defmodule Xandra.Connection.Utils do
     end
   end
 
+  # Parses ScyllaDB's sharding extension out of the options that the server
+  # returns in the SUPPORTED message (https://github.com/scylladb/scylladb/blob/master/docs/dev/protocol-extensions.md).
+  # Returns nil when not connected to ScyllaDB or when the sharding scheme is not
+  # one we support ("biased-token-round-robin" over the Murmur3 partitioner is
+  # the only scheme ScyllaDB defines). The shard-aware ports are optional since
+  # older ScyllaDB versions don't advertise them.
+  @spec parse_scylla_sharding_info(%{optional(String.t()) => [String.t()]}) :: map() | nil
+  def parse_scylla_sharding_info(supported_options) do
+    case supported_options do
+      %{
+        "SCYLLA_SHARD" => [shard],
+        "SCYLLA_NR_SHARDS" => [nr_shards],
+        "SCYLLA_SHARDING_IGNORE_MSB" => [sharding_ignore_msb],
+        "SCYLLA_SHARDING_ALGORITHM" => ["biased-token-round-robin"],
+        "SCYLLA_PARTITIONER" => ["org.apache.cassandra.dht.Murmur3Partitioner"]
+      } ->
+        %{
+          shard: String.to_integer(shard),
+          nr_shards: String.to_integer(nr_shards),
+          sharding_ignore_msb: String.to_integer(sharding_ignore_msb),
+          shard_aware_port: parse_optional_port(supported_options["SCYLLA_SHARD_AWARE_PORT"]),
+          shard_aware_port_ssl:
+            parse_optional_port(supported_options["SCYLLA_SHARD_AWARE_PORT_SSL"])
+        }
+
+      _other ->
+        nil
+    end
+  end
+
+  defp parse_optional_port([port]), do: String.to_integer(port)
+  defp parse_optional_port(_other), do: nil
+
   @spec startup_connection(Transport.t(), map(), module(), nil | module(), keyword()) ::
           :ok | {:error, ConnectionError.t()}
   def startup_connection(

--- a/test/integration/shard_awareness_test.exs
+++ b/test/integration/shard_awareness_test.exs
@@ -1,0 +1,175 @@
+defmodule ShardAwarenessTest do
+  # This test needs the multi-shard ScyllaDB instance (the scylladb_shard_aware
+  # service in docker-compose.yml), which listens on port 9072 and exposes the
+  # shard-aware port 19042.
+  use ExUnit.Case
+
+  alias Xandra.Cluster.Token
+
+  @moduletag :scylla_specific
+
+  @port String.to_integer(System.get_env("SCYLLA_SHARD_AWARE_CQL_PORT", "9072"))
+
+  setup do
+    protocol_version = XandraTest.IntegrationCase.protocol_version()
+
+    options = [
+      nodes: ["127.0.0.1:#{@port}"],
+      shard_awareness: true,
+      token_aware_routing: true,
+      sync_connect: 5000
+    ]
+
+    options =
+      if protocol_version do
+        Keyword.put(options, :protocol_version, protocol_version)
+      else
+        options
+      end
+
+    cluster = start_supervised!({Xandra.Cluster, options})
+    %{cluster: cluster, protocol_version: protocol_version}
+  end
+
+  test "discovers ScyllaDB sharding info and covers all shards (or cleanly falls back)",
+       %{cluster: cluster} do
+    pool_state = wait_for_sharding(cluster)
+
+    # The SUPPORTED options of the multi-shard ScyllaDB instance were parsed.
+    assert %{nr_shards: nr_shards, sharding_ignore_msb: _, shard_aware_port: 19_042} =
+             pool_state.sharding_info
+
+    assert nr_shards >= 2
+
+    cond do
+      pool_state.shard_aware_disabled? ->
+        # The environment rewrites source ports (NAT, Docker userland proxy) or
+        # blocks the shard-aware port, so Xandra correctly gave up. The plain
+        # pool must still work.
+        assert map_size(pool_state.connections) >= 1
+
+      true ->
+        covered_shards =
+          pool_state.connections
+          |> Enum.map(fn {_pid, %{shard: shard}} -> shard end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.uniq()
+          |> Enum.sort()
+
+        assert covered_shards == Enum.to_list(0..(nr_shards - 1))
+
+        # Checking out a connection for a token returns a connection on the
+        # shard that owns that token.
+        for token <- [0, -1, 12_345_678_901, -9_223_372_036_854_775_808] do
+          expected_shard =
+            Token.shard(token, nr_shards, pool_state.sharding_info.sharding_ignore_msb)
+
+          conn = Xandra.Cluster.ConnectionPool.checkout(pool_pid(cluster), token)
+          assert pool_state.connections[conn].shard == expected_shard
+        end
+    end
+  end
+
+  test "routes prepared queries by token end-to-end", %{
+    cluster: cluster,
+    protocol_version: protocol_version
+  } do
+    _pool_state = wait_for_sharding(cluster)
+
+    Xandra.Cluster.execute!(
+      cluster,
+      """
+      CREATE KEYSPACE IF NOT EXISTS xandra_test_shard_awareness
+      WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}
+      """,
+      []
+    )
+
+    Xandra.Cluster.execute!(
+      cluster,
+      "CREATE TABLE IF NOT EXISTS xandra_test_shard_awareness.items (id int PRIMARY KEY, name text)",
+      []
+    )
+
+    insert =
+      Xandra.Cluster.prepare!(
+        cluster,
+        "INSERT INTO xandra_test_shard_awareness.items (id, name) VALUES (?, ?)"
+      )
+
+    select =
+      Xandra.Cluster.prepare!(
+        cluster,
+        "SELECT name FROM xandra_test_shard_awareness.items WHERE id = ?"
+      )
+
+    # Protocol v4+ returns partition key indices for fully-bound partition
+    # keys; protocol v3 doesn't support them, so queries fall back to the
+    # load-balancing policy (but must still work).
+    if protocol_version == :v3 do
+      assert insert.pk_indices == nil
+      assert select.pk_indices == nil
+    else
+      assert insert.pk_indices == [0]
+      assert select.pk_indices == [0]
+    end
+
+    for id <- 1..50 do
+      Xandra.Cluster.execute!(cluster, insert, [id, "name-#{id}"])
+    end
+
+    for id <- 1..50 do
+      assert [%{"name" => name}] =
+               cluster |> Xandra.Cluster.execute!(select, [id]) |> Enum.to_list()
+
+      assert name == "name-#{id}"
+    end
+  end
+
+  defp pool_pid(cluster) do
+    {_state, data} = :sys.get_state(cluster)
+    [%{pool_pid: pool_pid}] = Map.values(data.peers)
+    pool_pid
+  end
+
+  # Digs the ShardManager state out of the pool supervisor.
+  defp shard_manager_state(cluster) do
+    {Xandra.Cluster.ConnectionPool.ShardManager, manager_pid, _type, _modules} =
+      cluster
+      |> pool_pid()
+      |> Supervisor.which_children()
+      |> List.keyfind(Xandra.Cluster.ConnectionPool.ShardManager, 0)
+
+    :sys.get_state(manager_pid)
+  end
+
+  # Waits for the connection pool to discover the sharding info of the host
+  # and to either cover all shards or give up on shard awareness.
+  defp wait_for_sharding(cluster, deadline \\ System.monotonic_time(:millisecond) + 10_000) do
+    pool_state = shard_manager_state(cluster)
+
+    all_shards_covered? =
+      match?(%{nr_shards: _}, pool_state.sharding_info) and
+        pool_state.sharding_info.nr_shards ==
+          pool_state.connections
+          |> Enum.map(fn {_pid, %{shard: shard}} -> shard end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.uniq()
+          |> length()
+
+    cond do
+      all_shards_covered? or pool_state.shard_aware_disabled? ->
+        pool_state
+
+      System.monotonic_time(:millisecond) > deadline ->
+        flunk("""
+        sharding info was not fully discovered in time. Pool state:
+        #{inspect(pool_state)}
+        """)
+
+      true ->
+        Process.sleep(100)
+        wait_for_sharding(cluster, deadline)
+    end
+  end
+end

--- a/test/xandra/cluster/connection_pool_test.exs
+++ b/test/xandra/cluster/connection_pool_test.exs
@@ -1,3 +1,163 @@
 defmodule Xandra.Cluster.ConnectionPoolTest do
   use ExUnit.Case, async: true
+
+  alias Xandra.Cluster.ConnectionPool
+  alias Xandra.Cluster.ConnectionPool.ShardManager
+
+  # An unreachable node: connections stay alive and retry with backoff, but
+  # never manage to connect.
+  @unreachable_node "127.0.0.1:9"
+
+  defp start_pool!(overrides \\ []) do
+    opts =
+      Keyword.merge(
+        [
+          connection_options: [nodes: [@unreachable_node]],
+          pool_size: 1,
+          shard_awareness: false
+        ],
+        overrides
+      )
+
+    start_supervised!({ConnectionPool, opts})
+  end
+
+  defp manager_pid(pool) do
+    {ShardManager, manager_pid, _type, _modules} =
+      pool |> Supervisor.which_children() |> List.keyfind(ShardManager, 0)
+
+    manager_pid
+  end
+
+  defp tracked_connections(manager_pid) do
+    # :sys.get_state/1 also acts as a synchronization barrier for the messages
+    # we send to the manager in these tests.
+    :sys.get_state(manager_pid).connections
+  end
+
+  defp wait_until(fun, deadline \\ System.monotonic_time(:millisecond) + 2000) do
+    result = fun.()
+
+    cond do
+      result -> result
+      System.monotonic_time(:millisecond) > deadline -> flunk("condition never became true")
+      true -> Process.sleep(10) && wait_until(fun, deadline)
+    end
+  end
+
+  test "checkout doesn't hand out connections that never connected" do
+    pool = start_pool!()
+    manager_pid = manager_pid(pool)
+
+    # The pool tracks its connection, but the connection can't connect.
+    assert map_size(tracked_connections(manager_pid)) == 1
+
+    assert ConnectionPool.checkout(pool) == nil
+    assert ConnectionPool.checkout(pool, _token = 0) == nil
+  end
+
+  test "checkout doesn't hand out connections that disconnected" do
+    pool = start_pool!()
+    manager_pid = manager_pid(pool)
+    [conn_pid] = Map.keys(tracked_connections(manager_pid))
+    peername = {{127, 0, 0, 1}, 9}
+
+    # Simulate the connection reporting a successful handshake on a
+    # single-shard ScyllaDB node.
+    sharding_info = %{
+      shard: 0,
+      nr_shards: 1,
+      sharding_ignore_msb: 12,
+      shard_aware_port: nil,
+      shard_aware_port_ssl: nil
+    }
+
+    send(manager_pid, {:xandra, :connected, peername, conn_pid})
+    send(manager_pid, {:xandra, :sharding_info, conn_pid, sharding_info})
+    assert %{^conn_pid => %{connected?: true, shard: 0}} = tracked_connections(manager_pid)
+
+    # Both plain and token-based checkouts return the connection while it's
+    # connected...
+    assert ConnectionPool.checkout(pool) == conn_pid
+    assert ConnectionPool.checkout(pool, _token = 0) == conn_pid
+
+    # ...and stop returning it once it disconnects, even for the shard that the
+    # connection was on.
+    send(manager_pid, {:xandra, :disconnected, peername, conn_pid})
+    assert %{^conn_pid => %{connected?: false}} = tracked_connections(manager_pid)
+
+    assert ConnectionPool.checkout(pool) == nil
+    assert ConnectionPool.checkout(pool, _token = 0) == nil
+  end
+
+  test "failures of restarted shard-targeted connections count towards giving up" do
+    # A "shard-aware port" that accepts TCP connections but never completes the
+    # CQL handshake, so shard-targeted connections started by the manager stay
+    # quietly connecting and the test fully controls the failure messages.
+    {:ok, listen_socket} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, shard_aware_port} = :inet.port(listen_socket)
+    on_exit(fn -> :gen_tcp.close(listen_socket) end)
+
+    pool = start_pool!(shard_awareness: true)
+    manager_pid = manager_pid(pool)
+    [base_conn_pid] = Map.keys(tracked_connections(manager_pid))
+    peername = {{127, 0, 0, 1}, shard_aware_port}
+
+    # Simulate the base connection reporting a two-shard ScyllaDB node, which
+    # makes the manager start a connection targeting the missing shard 1.
+    sharding_info = %{
+      shard: 0,
+      nr_shards: 2,
+      sharding_ignore_msb: 12,
+      shard_aware_port: shard_aware_port,
+      shard_aware_port_ssl: nil
+    }
+
+    send(manager_pid, {:xandra, :sharding_info, base_conn_pid, sharding_info})
+
+    connections_supervisor = connections_supervisor(pool)
+
+    targeted_conn_pid =
+      wait_until(fn -> targeted_conn_pid(connections_supervisor, _shard = 1) end)
+
+    assert %{^targeted_conn_pid => %{target_shard: 1}} = tracked_connections(manager_pid)
+
+    # Kill the targeted connection: its supervisor restarts it with a new PID
+    # that the manager doesn't know yet.
+    Process.exit(targeted_conn_pid, :kill)
+
+    restarted_conn_pid =
+      wait_until(fn ->
+        case targeted_conn_pid(connections_supervisor, _shard = 1) do
+          ^targeted_conn_pid -> nil
+          pid -> pid
+        end
+      end)
+
+    refute Map.has_key?(tracked_connections(manager_pid), restarted_conn_pid)
+
+    # If the restarted connection can only report connection failures, those
+    # must still count towards giving up on the shard-aware port.
+    for _failure <- 1..3 do
+      send(manager_pid, {:xandra, :failed_to_connect, peername, restarted_conn_pid})
+    end
+
+    wait_until(fn -> :sys.get_state(manager_pid).shard_aware_disabled? end)
+  end
+
+  defp connections_supervisor(pool) do
+    {:connections_supervisor, connections_supervisor, _type, _modules} =
+      pool |> Supervisor.which_children() |> List.keyfind(:connections_supervisor, 0)
+
+    connections_supervisor
+  end
+
+  defp targeted_conn_pid(connections_supervisor, shard) do
+    connections_supervisor
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn
+      {{:shard, ^shard}, pid, _type, _modules} when is_pid(pid) -> pid
+      _other -> nil
+    end)
+  end
 end


### PR DESCRIPTION
## Stack Context

PR 4 of 4 towards ScyllaDB shard awareness: keep partition key metadata → token/ring modules → token-aware routing → **shard awareness**. Closes #324.

## What?

New `shard_awareness: boolean()` option for `Xandra.Cluster.start_link/1`, **defaulting to `false`**. When enabled and the server is ScyllaDB:

- Connections parse ScyllaDB's sharding extension (`SCYLLA_SHARD`, `SCYLLA_NR_SHARDS`, `SCYLLA_SHARDING_IGNORE_MSB`, `SCYLLA_SHARD_AWARE_PORT`, ...) from the `SUPPORTED` message and report it to their pool.
- `Xandra.Cluster.ConnectionPool` stays a `Supervisor` (so all process lifecycle and shutdown semantics remain in supervision land) with two children: a `ShardManager` GenServer that holds the shard state and *monitors* (never links) the connections, and a plain supervisor for the connections themselves, which starts empty and gets populated by the manager. The `:one_for_all` strategy guarantees the manager's view can never go stale: if it crashes, the connections restart with it. The manager guarantees at least one connection per shard: missing shards are targeted deterministically by connecting to the shard-aware port (19042) from a local source port with `source_port % nr_shards == shard`.
- `ConnectionPool.checkout/2` takes the query token from the previous PR and hands out a connection on the shard that owns the token, so each query lands directly on the CPU core that owns the data.

Fallbacks (all exercised in tests or live verification): plain Cassandra, shard-aware port unreachable/firewalled (bounded connect attempts, then give up), NAT rewriting source ports (detected via shard mismatch, shard awareness disabled to avoid connection churn), and old ScyllaDB without the shard-aware port.

## Why?

ScyllaDB shards data per CPU core; without shard awareness every query has a 1-in-`nr_shards` chance of hitting the right core, and cross-shard hops cost latency. This is the ScyllaDB-driver feature requested in #324, implemented the same way as in the scylladb/python-driver and gocql forks.

Verified end-to-end against a 2-shard ScyllaDB (`--smp 2`, added to docker-compose along with an integration test): all shards get connections via source-port targeting, and token-based checkouts picked the owning shard in 200/200 trials, while the NAT-rewrite fallback was observed working through Docker Desktop's port proxy.