### PR TITLE
Preserve data-center order in token-aware routing

### DIFF
--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -268,8 +268,12 @@ defmodule Xandra.Cluster do
       hop between coordinator and replica for most queries. Token-aware routing is
       best-effort: if the replica is not connected (or the token cannot be computed, for
       example for simple queries, batches, or with native protocol v3), the query falls
-      back to the load-balancing policy. Only the Murmur3 partitioner (the default in both
-      Cassandra and ScyllaDB) is supported. *Available since v0.20.0*.
+      back to the load-balancing policy. It also never overrides the load-balancing
+      policy's *data-center order*: a primary replica in a remote data center is not
+      preferred over hosts in the local data center (with a data-center-aware policy
+      such as `Xandra.Cluster.LoadBalancingPolicy.DCAwareRoundRobin`). Only the Murmur3
+      partitioner (the default in both Cassandra and ScyllaDB) is supported.
+      *Available since v0.20.0*.
       """
     ],
     debug: [

--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -471,7 +471,7 @@ defmodule Xandra.Cluster.Pool do
   end
 
   # With token-aware routing, move the host that is the primary replica for the
-  # query's token to the front of the query plan, so that (when we have a
+  # query's token towards the front of the query plan, so that (when we have a
   # connection to it) the query is executed on a replica that owns the data.
   defp maybe_prioritize_token_owner(%__MODULE__{token_ring: ring}, query_plan, token)
        when is_nil(ring) or is_nil(token) do
@@ -479,11 +479,37 @@ defmodule Xandra.Cluster.Pool do
   end
 
   defp maybe_prioritize_token_owner(%__MODULE__{token_ring: ring}, query_plan, token) do
-    owner_peername = TokenRing.owner_peername(ring, token)
+    prioritize_token_owner(query_plan, TokenRing.owner_peername(ring, token))
+  end
 
-    case Enum.split_with(query_plan, &(Host.to_peername(&1) == owner_peername)) do
-      {[], _query_plan} -> query_plan
-      {owners, rest} -> owners ++ rest
+  # The owner is only promoted past hosts *in its own data center*, so that
+  # token-aware routing never overrides the load-balancing policy's data-center
+  # order (such as DCAwareRoundRobin putting the local DC first): without
+  # knowing the keyspace's replication, a remote-DC primary replica is not a
+  # better choice than local-DC replicas.
+  @doc false
+  @spec prioritize_token_owner(
+          Enumerable.t(Host.t()),
+          {:inet.ip_address() | String.t(), :inet.port_number()}
+        ) :: [Host.t()]
+  def prioritize_token_owner(query_plan, owner_peername) do
+    query_plan = Enum.to_list(query_plan)
+
+    case Enum.split_while(query_plan, &(Host.to_peername(&1) != owner_peername)) do
+      {_query_plan, []} ->
+        query_plan
+
+      {before_owner, [%Host{} = owner | after_owner]} ->
+        same_dc_before_owner =
+          before_owner
+          |> Enum.reverse()
+          |> Enum.take_while(&(&1.data_center == owner.data_center))
+          |> Enum.reverse()
+
+        other_dcs_before_owner =
+          Enum.take(before_owner, length(before_owner) - length(same_dc_before_owner))
+
+        other_dcs_before_owner ++ [owner] ++ same_dc_before_owner ++ after_owner
     end
   end
 

--- a/test/xandra/cluster/pool_test.exs
+++ b/test/xandra/cluster/pool_test.exs
@@ -1,0 +1,66 @@
+defmodule Xandra.Cluster.PoolTest do
+  use ExUnit.Case, async: true
+
+  alias Xandra.Cluster.Host
+  alias Xandra.Cluster.Pool
+
+  describe "prioritize_token_owner/2" do
+    test "moves the owner to the front when all hosts are in the same DC" do
+      [host1, host2, owner] = plan = [host(1, "dc1"), host(2, "dc1"), host(3, "dc1")]
+
+      assert Pool.prioritize_token_owner(plan, peername(owner)) == [owner, host1, host2]
+    end
+
+    test "treats hosts without a DC as being in the same DC" do
+      [host1, owner] = plan = [host(1, nil), host(2, nil)]
+
+      assert Pool.prioritize_token_owner(plan, peername(owner)) == [owner, host1]
+    end
+
+    test "doesn't promote a remote-DC owner past local-DC hosts" do
+      # DCAwareRoundRobin-style plan: local DC first, then the remote DC.
+      [local1, local2, owner, remote2] =
+        plan = [host(1, "local"), host(2, "local"), host(3, "remote"), host(4, "remote")]
+
+      # The owner is already at the front of its own DC's hosts, so nothing
+      # changes.
+      assert Pool.prioritize_token_owner(plan, peername(owner)) ==
+               [local1, local2, owner, remote2]
+
+      # Same, when the owner has to move to the front of its DC's hosts.
+      [local1, local2, remote1, owner] =
+        plan = [host(1, "local"), host(2, "local"), host(3, "remote"), host(4, "remote")]
+
+      assert Pool.prioritize_token_owner(plan, peername(owner)) ==
+               [local1, local2, owner, remote1]
+    end
+
+    test "promotes a local-DC owner to the front of a DC-aware plan" do
+      [local1, owner, remote1] = plan = [host(1, "local"), host(2, "local"), host(3, "remote")]
+
+      assert Pool.prioritize_token_owner(plan, peername(owner)) == [owner, local1, remote1]
+    end
+
+    test "never promotes the owner past a host in a different DC" do
+      # With DC-interleaved plans (like from the Random policy in a multi-DC
+      # cluster), the owner only passes the hosts of its own DC that
+      # immediately precede it.
+      [host1, host2, host3, owner] =
+        plan = [host(1, "dc1"), host(2, "dc2"), host(3, "dc1"), host(4, "dc1")]
+
+      assert Pool.prioritize_token_owner(plan, peername(owner)) == [host1, host2, owner, host3]
+    end
+
+    test "leaves the plan alone when the owner is not in it" do
+      plan = [host(1, "dc1"), host(2, "dc1")]
+
+      assert Pool.prioritize_token_owner(plan, peername(host(9, "dc1"))) == plan
+    end
+  end
+
+  defp host(last_ip_byte, data_center) do
+    %Host{address: {127, 0, 0, last_ip_byte}, port: 9042, data_center: data_center}
+  end
+
+  defp peername(%Host{} = host), do: Host.to_peername(host)
+end


### PR DESCRIPTION
## Stack Context

Follow-up fix to token-aware routing (#401), found while reviewing the shard-awareness stack for #324.

## What?

Token-aware routing no longer overrides the load-balancing policy's data-center order. When prioritizing the token's primary replica in the query plan, the owner is now only promoted past hosts *in its own data center* — it never jumps ahead of a host from a different DC.

## Why?

Previously the ring owner was pulled to the very front of the query plan unconditionally. With `DCAwareRoundRobin` (local DC first) and a partition whose primary replica lives in a remote DC, that routed the query across DCs even when local replicas were available — adding cross-DC latency and traffic cost.

Picking the *optimal* local replica would require knowing the keyspace's replication strategy (replica sets per token range), which Xandra doesn't track yet — that's future work. Until then, preserving the policy's DC order is the correct conservative behavior: a local owner still jumps to the front (the common single-DC and local-owner cases keep the full benefit), and a remote owner only gets priority within the remote portion of the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
