### PR TITLE
Stop clusters after sync connect timeouts

### DIFF
--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -39,6 +39,7 @@ defmodule Xandra.Cluster.Pool do
         after
           sync_connect_timeout ->
             if sync_connect_alias_or_nil, do: Process.unalias(sync_connect_alias_or_nil)
+            stop_after_sync_connect_timeout(pid)
             {:error, :sync_connect_timeout}
         end
 
@@ -754,6 +755,16 @@ defmodule Xandra.Cluster.Pool do
 
   defp timeout_action(name, time) do
     {{:timeout, name}, time, _event_content = nil}
+  end
+
+  defp stop_after_sync_connect_timeout(pid) do
+    monitor_ref = Process.monitor(pid)
+    Process.unlink(pid)
+    Process.exit(pid, :kill)
+
+    receive do
+      {:DOWN, ^monitor_ref, :process, ^pid, _reason} -> :ok
+    end
   end
 
   defp execute_telemetry(%__MODULE__{} = state, event_postfix, measurements, extra_meta) do

--- a/test/xandra/cluster_test.exs
+++ b/test/xandra/cluster_test.exs
@@ -227,9 +227,18 @@ defmodule Xandra.ClusterTest do
       assert_received {[:xandra, :connected], ^telemetry_ref, %{}, %{}}
     end
 
-    test "times out correctly with :sync_connect", %{base_options: opts} do
-      opts = Keyword.merge(opts, sync_connect: 0)
+    test "stops the cluster if :sync_connect times out", %{base_options: opts} do
+      name = :sync_connect_timeout_cluster
+
+      opts =
+        Keyword.merge(opts,
+          control_connection_module: ControlConnectionMock,
+          name: name,
+          sync_connect: 0
+        )
+
       assert {:error, :sync_connect_timeout} = Cluster.start_link(opts)
+      refute Process.whereis(name)
     end
 
     @tag :capture_log


### PR DESCRIPTION
Stop the cluster process when sync connect times out.