### PR TITLE
Handle down events for unknown hosts

### DIFF
--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -286,11 +286,18 @@ defmodule Xandra.Cluster.Pool do
   def handle_event(:info, {:host_down, address, port}, _state, %__MODULE__{} = data) do
     # Set the host's status as :down, regardless of its current state.
     peername = {address, port}
-    data = set_host_status(data, peername, :down)
-    host = data.peers[peername].host
-    data = stop_pool(data, host)
-    data = maybe_start_pools(data)
-    {:keep_state, data}
+
+    case data.peers[peername] do
+      nil ->
+        send(data.control_connection, :refresh_topology)
+        {:keep_state, data}
+
+      %{host: %Host{} = host} ->
+        data = set_host_status(data, peername, :down)
+        data = stop_pool(data, host)
+        data = maybe_start_pools(data)
+        {:keep_state, data}
+    end
   end
 
   def handle_event(:info, {:discovered_hosts, new_peers}, _state, %__MODULE__{} = data)

--- a/test/xandra/cluster_test.exs
+++ b/test/xandra/cluster_test.exs
@@ -48,6 +48,11 @@ defmodule Xandra.ClusterTest do
     def handle_info({:started_pool, %Host{}}, state) do
       {:noreply, state}
     end
+
+    def handle_info(:refresh_topology, {test_pid, test_ref} = state) do
+      send(test_pid, {test_ref, __MODULE__, :refresh_topology})
+      {:noreply, state}
+    end
   end
 
   defmacrop assert_telemetry(postfix, meta) do
@@ -893,31 +898,27 @@ defmodule Xandra.ClusterTest do
       get_state(pid)
     end
 
-    @tag telemetry_events: [
-           [:xandra, :cluster, :pool, :started],
-           [:xandra, :cluster, :change_event],
-           [:xandra, :cluster, :discovered_peers]
-         ]
     test "receiving change events of a yet unknown host triggers a :refresh_topology", %{
       base_options: opts,
-      telemetry_ref: telemetry_ref
+      test_ref: test_ref
     } do
+      opts =
+        Keyword.merge(opts,
+          control_connection_module: ControlConnectionMock,
+          sync_connect: false
+        )
+
       pid = start_supervised!({Cluster, opts})
       bad_host = %Host{address: {127, 0, 0, 1}, port: 9999}
-      assert_receive {[:xandra, :cluster, :pool, :started], ^telemetry_ref, %{}, %{}}
+      assert_control_connection_started(test_ref)
 
-      assert_receive {[:xandra, :cluster, :change_event], ^telemetry_ref, %{},
-                      %{event_type: :host_added}}
+      send(pid, {:host_up, bad_host.address, bad_host.port})
+      assert_receive {^test_ref, ControlConnectionMock, :refresh_topology}
 
-      send(pid, {:host_up, bad_host})
+      send(pid, {:host_down, bad_host.address, bad_host.port})
+      assert_receive {^test_ref, ControlConnectionMock, :refresh_topology}
 
-      assert_receive {[:xandra, :cluster, :discovered_peers], ^telemetry_ref,
-                      %{peers: [%Host{address: {127, 0, 0, 1}, port: @port}]}, _cluster_info}
-
-      send(pid, {:host_down, bad_host})
-
-      assert_receive {[:xandra, :cluster, :discovered_peers], ^telemetry_ref,
-                      %{peers: [%Host{address: {127, 0, 0, 1}, port: @port}]}, _cluster_info}
+      assert Process.alive?(pid)
     end
   end
 


### PR DESCRIPTION
Refresh topology without crashing on unknown DOWN events.