### PR TITLE
Bracket IPv6 peer addresses

### DIFF
--- a/lib/xandra/cluster/host.ex
+++ b/lib/xandra/cluster/host.ex
@@ -108,6 +108,12 @@ defmodule Xandra.Cluster.Host do
   @doc since: "0.15.0"
   @spec format_peername({:inet.ip_address() | String.t(), :inet.port_number()}) ::
           String.t()
+  def format_peername({address, port})
+      when is_tuple(address) and tuple_size(address) == 8 and is_integer(port) and
+             port in 0..65_535 do
+    "[#{:inet.ntoa(address)}]:#{port}"
+  end
+
   def format_peername({address, port}) when is_integer(port) and port in 0..65_535 do
     if ip_address?(address) do
       "#{:inet.ntoa(address)}:#{port}"

--- a/test/xandra/cluster/host_test.exs
+++ b/test/xandra/cluster/host_test.exs
@@ -13,7 +13,7 @@ defmodule Xandra.Cluster.HostTest do
 
     test "formats an IPv6 address" do
       host = %Host{address: {0, 0, 0, 0, 0, 0, 0, 1}, port: 9042}
-      assert Host.format_address(host) == "::1:9042"
+      assert Host.format_address(host) == "[::1]:9042"
     end
 
     test "formats a hostname" do


### PR DESCRIPTION
Bracket IPv6 peer addresses before reusing them as nodes.