### PR TITLE
Preserve discovered peer order

### DIFF
--- a/lib/xandra/cluster/pool.ex
+++ b/lib/xandra/cluster/pool.ex
@@ -306,6 +306,7 @@ defmodule Xandra.Cluster.Pool do
 
     new_peers_map = Map.new(new_peers, &{Host.to_peername(&1), &1})
     new_peers_set = MapSet.new(new_peers, &Host.to_peername/1)
+    new_peers_order = new_peers |> Enum.map(&Host.to_peername/1) |> Enum.uniq()
     old_peers_set = data.peers |> Map.keys() |> MapSet.new()
 
     # Find the peers that are not in the set of known peers anymore, remove them
@@ -319,8 +320,12 @@ defmodule Xandra.Cluster.Pool do
     # For the new peers that we didn't know about, add them to the LBP, emit a
     # telemetry event, and potentially start pools.
     data =
-      Enum.reduce(MapSet.difference(new_peers_set, old_peers_set), data, fn peername, data_acc ->
-        handle_host_added(data_acc, Map.fetch!(new_peers_map, peername))
+      Enum.reduce(new_peers_order, data, fn peername, data_acc ->
+        if MapSet.member?(old_peers_set, peername) do
+          data_acc
+        else
+          handle_host_added(data_acc, Map.fetch!(new_peers_map, peername))
+        end
       end)
 
     # For the peers that we already knew about, refresh their info (their

--- a/test/xandra/cluster_test.exs
+++ b/test/xandra/cluster_test.exs
@@ -888,6 +888,38 @@ defmodule Xandra.ClusterTest do
              |> List.keyfind({{127, 0, 0, 1}, 8092}, 0) == nil
     end
 
+    test "adds discovered hosts to the load balancing policy in order", %{test_ref: test_ref} do
+      opts = [
+        xandra_module: PoolMock,
+        control_connection_module: ControlConnectionMock,
+        nodes: ["node1"],
+        sync_connect: false,
+        target_pools: 2,
+        load_balancing: {Xandra.Cluster.LoadBalancingPolicy.DCAwareRoundRobin, []}
+      ]
+
+      pid = start_supervised!({Cluster, opts})
+      assert_control_connection_started(test_ref)
+
+      first_host = %Host{
+        address: {198, 10, 0, 9},
+        port: @port,
+        data_center: "first_dc"
+      }
+
+      second_host = %Host{
+        address: {198, 0, 0, 1},
+        port: @port,
+        data_center: "second_dc"
+      }
+
+      send(pid, {:discovered_hosts, [first_host, second_host]})
+
+      assert Xandra.Cluster.LoadBalancingPolicy.DCAwareRoundRobin.local_dc(
+               get_state(pid).load_balancing_state
+             ) == "first_dc"
+    end
+
     @tag telemetry_events: [[:xandra, :cluster, :pool, :started]]
     test ":host_up is idempotent", %{base_options: opts, telemetry_ref: telemetry_ref} do
       pid = start_supervised!({Cluster, opts})


### PR DESCRIPTION
Keep discovery order when choosing the local data center.